### PR TITLE
move media apps to app-template chart

### DIFF
--- a/cluster/apps/media/prowlarr/helm-release.yaml
+++ b/cluster/apps/media/prowlarr/helm-release.yaml
@@ -9,13 +9,19 @@ spec:
   chart:
     spec:
       # renovate: registryUrl=https://k8s-at-home.com/charts/
-      chart: prowlarr
-      version: 4.5.2
+      chart: app-template
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
-        name: k8s-at-home-charts
+        name: bjw-s-charts
         namespace: flux-system
-      interval: 5m
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
   values:
     image:
       repository: ghcr.io/onedr0p/prowlarr-develop

--- a/cluster/apps/media/radarr/helm-release.yaml
+++ b/cluster/apps/media/radarr/helm-release.yaml
@@ -9,13 +9,19 @@ spec:
   chart:
     spec:
       # renovate: registryUrl=https://k8s-at-home.com/charts/
-      chart: radarr
-      version: 16.3.2
+      chart: app-template
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
-        name: k8s-at-home-charts
+        name: bjw-s-charts
         namespace: flux-system
-      interval: 5m
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
   values:
     image:
       repository: ghcr.io/onedr0p/radarr

--- a/cluster/apps/media/readarr/helm-release.yaml
+++ b/cluster/apps/media/readarr/helm-release.yaml
@@ -9,13 +9,19 @@ spec:
   chart:
     spec:
       # renovate: registryUrl=https://k8s-at-home.com/charts/
-      chart: readarr
-      version: 6.4.2
+      chart: app-template
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
-        name: k8s-at-home-charts
+        name: bjw-s-charts
         namespace: flux-system
-      interval: 5m
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
   values:
     image:
       repository: ghcr.io/onedr0p/readarr-develop

--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -9,13 +9,19 @@ spec:
   chart:
     spec:
       # renovate: registryUrl=https://k8s-at-home.com/charts/
-      chart: sonarr
-      version: 16.3.2
+      chart: app-template
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
-        name: k8s-at-home-charts
+        name: bjw-s-charts
         namespace: flux-system
-      interval: 5m
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
   values:
     image:
       repository: ghcr.io/onedr0p/sonarr

--- a/cluster/apps/media/transmission/helm-release.yaml
+++ b/cluster/apps/media/transmission/helm-release.yaml
@@ -5,17 +5,23 @@ metadata:
   name: transmission
   namespace: media
 spec:
-  interval: 5m
+  interval: 15m
   chart:
     spec:
       # renovate: registryUrl=https://k8s-at-home.com/charts/
-      chart: transmission
-      version: 8.4.3
+      chart: app-template
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
-        name: k8s-at-home-charts
+        name: bjw-s-charts
         namespace: flux-system
-      interval: 5m
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
   values:
     image:
       repository: ghcr.io/onedr0p/transmission
@@ -28,16 +34,16 @@ spec:
       type: statefulset
     env:
       TZ: Europe/Warsaw
-      TRANSMISSION_BLOCKLIST_URL: "https://mirror.codebucket.de/transmission/blocklist.p2p.gz"
-      TRANSMISSION_DOWNLOAD_DIR: "/downloads"
-      TRANSMISSION_INCOMPLETE_DIR_ENABLED: false
-      TRANSMISSION_RATIO_LIMIT: 1
-      TRANSMISSION_RATIO_LIMIT_ENABLED: true
-      TRANSMISSION_RPC_PASSWORD: "${TRANSMISSION_RPC_PASSWORD}"
-      TRANSMISSION_SPEED_LIMIT_UP_ENABLED: true
-      TRANSMISSION_SPEED_LIMIT_UP: 8000
-      TRANSMISSION_UMASK: 7
-      TRANSMISSION_WEB_HOME: "/app/web"
+      TRANSMISSION__BLOCKLIST_URL: "https://mirror.codebucket.de/transmission/blocklist.p2p.gz"
+      TRANSMISSION__DOWNLOAD_DIR: "/downloads"
+      TRANSMISSION__INCOMPLETE_DIR_ENABLED: false
+      TRANSMISSION__RATIO_LIMIT: 1
+      TRANSMISSION__RATIO_LIMIT_ENABLED: true
+      TRANSMISSION__RPC_PASSWORD: "${TRANSMISSION_RPC_PASSWORD}"
+      TRANSMISSION__SPEED_LIMIT_UP_ENABLED: true
+      TRANSMISSION__SPEED_LIMIT_UP: 8000
+      TRANSMISSION__UMASK: 7
+      TRANSMISSION__WEB_HOME: "/app/web"
     resources:
       requests:
         cpu: 100m

--- a/cluster/charts/bjw-s-charts.yaml
+++ b/cluster/charts/bjw-s-charts.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bjw-s-charts
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://bjw-s.github.io/helm-charts/

--- a/cluster/charts/kustomization.yaml
+++ b/cluster/charts/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - bjw-s-charts.yaml
   - democratic-csi.yaml
   - external-dns-charts.yaml
   - hajimari-charts.yaml


### PR DESCRIPTION
**Description of the change**

The k8s@home charts are deprecated. Move them to the apptemplate chart

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
