### PR TITLE
Feat: gracefull shutdown

### DIFF
--- a/ansible/inventory/group_vars/kubernetes/k3s.yml
+++ b/ansible/inventory/group_vars/kubernetes/k3s.yml
@@ -5,7 +5,7 @@
 #
 
 # (string) Use a specific version of k3s
-k3s_release_version: "v1.24.8+k3s1"
+k3s_release_version: "v1.24.9+k3s2"
 
 # (bool) Install using hard links rather than symbolic links.
 k3s_install_hard_links: true

--- a/ansible/inventory/group_vars/master/k3s.yml
+++ b/ansible/inventory/group_vars/master/k3s.yml
@@ -33,7 +33,7 @@ k3s_server:
   kubelet-arg:
     # Enables the kubelet to gracefully evict pods during a node shutdown
     - "feature-gates=GracefulNodeShutdown=true"
-    - "config=/etc/rancher/k3s/kubelet.config"
+    - "config=/etc/rancher/k3s/kubelet.conf"
     # Allow pods to be rescheduled quicker in the case of a node failure
     # https://github.com/k3s-io/k3s/issues/1264
     - "node-status-update-frequency=4s"

--- a/ansible/inventory/group_vars/master/k3s.yml
+++ b/ansible/inventory/group_vars/master/k3s.yml
@@ -33,6 +33,7 @@ k3s_server:
   kubelet-arg:
     # Enables the kubelet to gracefully evict pods during a node shutdown
     - "feature-gates=GracefulNodeShutdown=true"
+    - "config=/etc/rancher/k3s/kubelet.config"
     # Allow pods to be rescheduled quicker in the case of a node failure
     # https://github.com/k3s-io/k3s/issues/1264
     - "node-status-update-frequency=4s"

--- a/ansible/inventory/group_vars/worker/k3s.yml
+++ b/ansible/inventory/group_vars/worker/k3s.yml
@@ -11,7 +11,7 @@ k3s_agent:
   kubelet-arg:
     # Enables the kubelet to gracefully evict pods during a node shutdown
     - "feature-gates=GracefulNodeShutdown=true"
-    - "config=/etc/rancher/k3s/kubelet.config"
+    - "config=/etc/rancher/k3s/kubelet.conf"
     # Allow k8s services to contain TCP and UDP on the same port
     - "feature-gates=MixedProtocolLBService=true"
   kube-proxy-arg:

--- a/ansible/inventory/group_vars/worker/k3s.yml
+++ b/ansible/inventory/group_vars/worker/k3s.yml
@@ -11,6 +11,7 @@ k3s_agent:
   kubelet-arg:
     # Enables the kubelet to gracefully evict pods during a node shutdown
     - "feature-gates=GracefulNodeShutdown=true"
+    - "config=/etc/rancher/k3s/kubelet.config"
     # Allow k8s services to contain TCP and UDP on the same port
     - "feature-gates=MixedProtocolLBService=true"
   kube-proxy-arg:

--- a/ansible/playbooks/files/kubelet.conf
+++ b/ansible/playbooks/files/kubelet.conf
@@ -1,0 +1,4 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+shutdownGracePeriod: 180s
+shutdownGracePeriodCriticalPods: 30s

--- a/ansible/playbooks/k3s-installation.yml
+++ b/ansible/playbooks/k3s-installation.yml
@@ -23,6 +23,20 @@
         k3s_server_manifests_urls: []
       when: k3s_check_installed.stat.exists
 
+    - name: Create rancher dirs
+      ansible.builtin.file:
+        path: /etc/rancher
+        owner: root
+        group: root
+        mode: 0755
+        state: directory
+
+    - name: Install kubelet config
+      ansible.builtin.copy:
+        src: files/kubelet.conf
+        dest: /etc/rancher/k3s/kubelet.conf
+        mode: 0644
+
     - name: Install Kubernetes
       ansible.builtin.include_role:
         name: xanmanning.k3s

--- a/ansible/playbooks/tasks/ubuntu/kernel.yml
+++ b/ansible/playbooks/tasks/ubuntu/kernel.yml
@@ -16,7 +16,7 @@
     - acpiphp
     - pci_hotplug
     - nvme_core
-    - nvme_fabric
+    - nvme_fabrics
     - nvme_tcp
 
 - name: Enable kernel modules on boot

--- a/ansible/playbooks/tasks/ubuntu/packages.yml
+++ b/ansible/playbooks/tasks/ubuntu/packages.yml
@@ -73,6 +73,11 @@
           "${distro_id} ${distro_codename}-updates";
       };
 
+- name: Delete the inhibitor setting
+  ansible.builtin.file:
+    path: /lib/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf
+    state: absent
+
 - name: Start unattended-upgrades service
   ansible.builtin.systemd:
     name: unattended-upgrades


### PR DESCRIPTION
**Description of the change**

The nodes now gracefully shutdown, evicting pods before going down

**Benefits**

Shutdown/reboot doesn't take 20 minutes and leave broken pods

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

It is critical that on ubuntu the unattended-upgrades inhibitor file is killed *before* k3s starts. Otherwise logind will ignore anything it does
