### PR TITLE
feat(monitor): add drm-exporter

### DIFF
--- a/kubernetes/apps/monitor/drm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/monitor/drm-exporter/app/helmrelease.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: drm-exporter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: drm-exporter
+  interval: 30m
+  values:
+    dra:
+      enabled: true
+      deviceClassName: gpu.intel.com
+    securityContext:
+      capabilities:
+        add:
+          - PERFMON
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            grafana.internal/instance: grafana
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 128Mi

--- a/kubernetes/apps/monitor/drm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/monitor/drm-exporter/app/helmrelease.yaml
@@ -17,6 +17,7 @@ spec:
       capabilities:
         add:
           - PERFMON
+          - SYS_RAWIO
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/monitor/drm-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/monitor/drm-exporter/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitor
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/monitor/drm-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/monitor/drm-exporter/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: drm-exporter
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.0
+  url: oci://ghcr.io/home-operations/charts/drm-exporter

--- a/kubernetes/apps/monitor/drm-exporter/ks.yaml
+++ b/kubernetes/apps/monitor/drm-exporter/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app drm-exporter
+  namespace: &namespace monitor
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: intel-gpu-resource-driver
+      namespace: kube-system
+  interval: 30m
+  path: ./kubernetes/apps/monitor/drm-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab-ops
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/monitor/kustomization.yaml
+++ b/kubernetes/apps/monitor/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../components/alerts
   - ../../components/namespace
 resources:
+  - ./drm-exporter/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana-operator/ks.yaml
   - ./kromgo/ks.yaml


### PR DESCRIPTION
## Summary
- add `drm-exporter` under `kubernetes/apps/monitor` instead of `kube-system`
- keep the dependency on `intel-gpu-resource-driver` in `kube-system`
- adapt YAML language server schema headers to this repo's `crd.movishell.pl` convention
- wire Grafana Operator dashboard selection to this repo's Grafana instance labels

## Details
This follows the `onedr0p/home-ops` `drm-exporter` deployment pattern, with repo-specific adjustments:
- Flux `Kustomization` lives in the `monitor` namespace
- app path is `./kubernetes/apps/monitor/drm-exporter/app`
- `targetNamespace` is `monitor`
- dashboard selector uses `grafana.internal/instance: grafana` to match the existing Grafana Operator setup here

## Chart values
- `dra.enabled: true`
- `dra.deviceClassName: gpu.intel.com`
- `monitoring.serviceMonitor.enabled: true`
- `monitoring.dashboards.enabled: true`
- `monitoring.dashboards.grafanaOperator.enabled: true`
- `securityContext.capabilities.add: [PERFMON]`
- resource request/limit aligned with the referenced example

## Validation
- repo pre-commit `format-yaml` hook ran successfully during commit
- Zed diagnostics report no issues in the new YAML files
