### PR TITLE
feat(monitoring): add TrueNAS drm-exporter scrape

### DIFF
--- a/docker/truenas/02-exporters/docker-compose.yml
+++ b/docker/truenas/02-exporters/docker-compose.yml
@@ -30,3 +30,19 @@ services:
     privileged: true
     restart: unless-stopped
     user: root
+
+  drm-exporter:
+    image: ghcr.io/home-operations/drm-exporter:0.2.4@sha256:1ccf3c6db20bcd95bc4d69eac7a5288c92543b34adbe053004c1b739fd0208ef
+    container_name: drm-exporter
+    restart: unless-stopped
+    user: root
+    environment:
+      DRM_EXPORTER_PORT: 9087
+      DRM_EXPORTER_INTERVAL_SECONDS: 5
+      RUST_LOG: info
+    ports:
+      - 9087:9087
+    devices:
+      - /dev/dri:/dev/dri
+    volumes:
+      - /sys:/sys:ro

--- a/kubernetes/apps/monitor/drm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/monitor/drm-exporter/app/helmrelease.yaml
@@ -17,7 +17,6 @@ spec:
       capabilities:
         add:
           - PERFMON
-          - SYS_RAWIO
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/monitor/kube-prometheus-stack/app/scrapeconfigs/drm-exporter.yaml
+++ b/kubernetes/apps/monitor/kube-prometheus-stack/app/scrapeconfigs/drm-exporter.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name drm-exporter
+spec:
+  staticConfigs: [targets: ["leo.${PRIVATE_DOMAIN}:9087"]]
+  metricsPath: /metrics
+  honorTimestamps: true
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - sourceLabels: [__address__]
+      regex: '([^:]+):\d+'
+      replacement: "$1"
+      targetLabel: instance

--- a/kubernetes/apps/monitor/kube-prometheus-stack/app/scrapeconfigs/kustomization.yaml
+++ b/kubernetes/apps/monitor/kube-prometheus-stack/app/scrapeconfigs/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./dexd.yaml
   - ./dococd.yaml
+  - ./drm-exporter.yaml
   - ./node-exporter.yaml
   - ./rustfs.yaml
   - ./smartctl-exporter.yaml


### PR DESCRIPTION
## Summary

Add `drm-exporter` for the TrueNAS NAS exporters stack and scrape it from `kube-prometheus-stack`.

## Changes

- add `drm-exporter` to `docker/truenas/02-exporters/docker-compose.yml`
  - use tagged+digested image reference for Renovate compatibility:
    - `ghcr.io/home-operations/drm-exporter:0.2.4@sha256:1ccf3c6db20bcd95bc4d69eac7a5288c92543b34adbe053004c1b739fd0208ef`
  - expose it on `9087` instead of generic `8081`
  - mount `/dev/dri` and `/sys` for GPU metrics
  - drop extra capabilities on the AMD iGPU / TrueNAS side
- add `kubernetes/apps/monitor/kube-prometheus-stack/app/scrapeconfigs/drm-exporter.yaml`
  - scrape target: `leo.${PRIVATE_DOMAIN}:9087`
- include the new scrape config from `kubernetes/apps/monitor/kube-prometheus-stack/app/scrapeconfigs/kustomization.yaml`
- remove `SYS_RAWIO` from `kubernetes/apps/monitor/drm-exporter/app/helmrelease.yaml`
  - Talos does not expose the MSR path, so this capability is not useful there

## Notes

- `PERFMON` was removed only from the TrueNAS docker service because that side is expected to run on an AMD iGPU.
- `PERFMON` was intentionally left in the Kubernetes `HelmRelease` because that deployment is still using the Intel GPU device class (`gpu.intel.com`).

## Validation

- `docker compose -f docker/truenas/02-exporters/docker-compose.yml config`
- `kubectl kustomize kubernetes/apps/monitor/kube-prometheus-stack/app/scrapeconfigs`
- `kubectl kustomize kubernetes/apps/monitor/drm-exporter/app`