### PR TITLE
fix(monitor): use default apiserver service discovery

### DIFF
--- a/kubernetes/apps/monitor/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitor/kube-prometheus-stack/app/helmrelease.yaml
@@ -17,11 +17,6 @@ spec:
     crds:
       enabled: true
     cleanPrometheusOperatorObjectNames: true
-    kubeApiServer:
-      serviceMonitor:
-        selector:
-          matchLabels:
-            k8s-app: kube-apiserver
     kubeScheduler:
       service:
         selector:


### PR DESCRIPTION
## Summary
- remove the `kubeApiServer` override from `kubernetes/apps/monitor/kube-prometheus-stack/app/helmrelease.yaml`
- fall back to the upstream `kube-prometheus-stack` default apiserver `ServiceMonitor` selector
- avoid requiring the non-existent `k8s-app: kube-apiserver` label on the `default/kubernetes` Service

## Why
The previous override caused Prometheus to discover zero apiserver targets in this cluster, which left `up{job="apiserver"}` absent and triggered the `KubeAPIDown` alert.

Upstream defaults already match this cluster correctly by selecting:
- `component: apiserver`
- `provider: kubernetes`

## Validation
- inspected upstream chart defaults and apiserver `ServiceMonitor` template
- removed the redundant/broken override
- pre-commit formatting passed (`format-yaml`)

## Follow-up
After merge/reconcile, verify:
- the rendered `ServiceMonitor` no longer requires `k8s-app: kube-apiserver`
- `up{job="apiserver"}` returns targets
- `KubeAPIDown` clears
