### PR TITLE
chore: bootstrap kopiur backups alongside volsync

### DIFF
--- a/kubernetes/apps/downloads/bazarr/ks.yaml
+++ b/kubernetes/apps/downloads/bazarr/ks.yaml
@@ -32,7 +32,6 @@ spec:
       PVC_CLAIM: bazarr-config
       PVC_STORAGECLASS: &sc dcsi-nfs
       KOPIUR_SNAPSHOTCLASS: *sc
-      KOPIUR_TIME: 0 2 * * *
       VOLSYNC_SNAPSHOTCLASS: *sc
       VOLSYNC_TIME: 0 2 * * *
   prune: true

--- a/kubernetes/apps/downloads/bazarr/ks.yaml
+++ b/kubernetes/apps/downloads/bazarr/ks.yaml
@@ -19,8 +19,6 @@ spec:
       namespace: storage
     - name: kopiur
       namespace: storage
-    - name: kopiur-repository
-      namespace: storage
     - name: volsync
       namespace: storage
   interval: 30m

--- a/kubernetes/apps/downloads/bazarr/ks.yaml
+++ b/kubernetes/apps/downloads/bazarr/ks.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   components:
     - ../../../../components/authentik-proxy
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: postgres-cluster
@@ -15,6 +16,10 @@ spec:
     - name: external-secrets
       namespace: security
     - name: dcsi-nfs
+      namespace: storage
+    - name: kopiur
+      namespace: storage
+    - name: kopiur-repository
       namespace: storage
     - name: volsync
       namespace: storage
@@ -28,6 +33,8 @@ spec:
       HOSTNAME: bazarr.${PUBLIC_DOMAIN}
       PVC_CLAIM: bazarr-config
       PVC_STORAGECLASS: &sc dcsi-nfs
+      KOPIUR_SNAPSHOTCLASS: *sc
+      KOPIUR_TIME: 0 2 * * *
       VOLSYNC_SNAPSHOTCLASS: *sc
       VOLSYNC_TIME: 0 2 * * *
   prune: true

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -8,9 +8,14 @@ metadata:
 spec:
   components:
     - ../../../../components/authentik-proxy
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: dcsi-nfs
+      namespace: storage
+    - name: kopiur
+      namespace: storage
+    - name: kopiur-repository
       namespace: storage
     - name: volsync
       namespace: storage
@@ -24,6 +29,8 @@ spec:
       HOSTNAME: torrent.${PUBLIC_DOMAIN}
       PVC_CLAIM: qbittorrent-config
       PVC_STORAGECLASS: &sc dcsi-nfs
+      KOPIUR_SNAPSHOTCLASS: *sc
+      KOPIUR_TIME: 0 4 * * *
       VOLSYNC_SNAPSHOTCLASS: *sc
       VOLSYNC_TIME: 0 4 * * *
   prune: true

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -28,7 +28,6 @@ spec:
       PVC_CLAIM: qbittorrent-config
       PVC_STORAGECLASS: &sc dcsi-nfs
       KOPIUR_SNAPSHOTCLASS: *sc
-      KOPIUR_TIME: 0 4 * * *
       VOLSYNC_SNAPSHOTCLASS: *sc
       VOLSYNC_TIME: 0 4 * * *
   prune: true

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -15,8 +15,6 @@ spec:
       namespace: storage
     - name: kopiur
       namespace: storage
-    - name: kopiur-repository
-      namespace: storage
     - name: volsync
       namespace: storage
   interval: 30m

--- a/kubernetes/apps/downloads/recyclarr/ks.yaml
+++ b/kubernetes/apps/downloads/recyclarr/ks.yaml
@@ -7,10 +7,15 @@ metadata:
   namespace: &namespace downloads
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: external-secrets
       namespace: security
+    - name: kopiur
+      namespace: storage
+    - name: kopiur-repository
+      namespace: storage
   interval: 30m
   path: ./kubernetes/apps/downloads/recyclarr/app
   postBuild:
@@ -18,6 +23,7 @@ spec:
       APP: *app
       PVC_CLAIM: recyclarr-config
       PVC_STORAGECLASS: &sc dcsi-nfs
+      KOPIUR_SNAPSHOTCLASS: *sc
       VOLSYNC_SNAPSHOTCLASS: *sc
   prune: true
   sourceRef:

--- a/kubernetes/apps/downloads/recyclarr/ks.yaml
+++ b/kubernetes/apps/downloads/recyclarr/ks.yaml
@@ -14,8 +14,6 @@ spec:
       namespace: security
     - name: kopiur
       namespace: storage
-    - name: kopiur-repository
-      namespace: storage
   interval: 30m
   path: ./kubernetes/apps/downloads/recyclarr/app
   postBuild:

--- a/kubernetes/apps/security/vaultwarden/ks.yaml
+++ b/kubernetes/apps/security/vaultwarden/ks.yaml
@@ -28,7 +28,6 @@ spec:
       PVC_ACCESSMODES: ReadWriteMany
       PVC_STORAGECLASS: &nfs dcsi-nfs
       KOPIUR_SNAPSHOTCLASS: *nfs
-      KOPIUR_TIME: 0 15 * * *
       VOLSYNC_SNAPSHOTCLASS: *nfs
       VOLSYNC_TIME: 0 15 * * *
   prune: true

--- a/kubernetes/apps/security/vaultwarden/ks.yaml
+++ b/kubernetes/apps/security/vaultwarden/ks.yaml
@@ -16,8 +16,6 @@ spec:
       namespace: security
     - name: kopiur
       namespace: storage
-    - name: kopiur-repository
-      namespace: storage
   interval: 30m
   path: ./kubernetes/apps/security/vaultwarden/app
   postBuild:

--- a/kubernetes/apps/security/vaultwarden/ks.yaml
+++ b/kubernetes/apps/security/vaultwarden/ks.yaml
@@ -7,12 +7,17 @@ metadata:
   namespace: &namespace security
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: postgres-cluster
       namespace: database
     - name: external-secrets
       namespace: security
+    - name: kopiur
+      namespace: storage
+    - name: kopiur-repository
+      namespace: storage
   interval: 30m
   path: ./kubernetes/apps/security/vaultwarden/app
   postBuild:
@@ -24,6 +29,8 @@ spec:
       PVC_CLAIM: vaultwarden-data
       PVC_ACCESSMODES: ReadWriteMany
       PVC_STORAGECLASS: &nfs dcsi-nfs
+      KOPIUR_SNAPSHOTCLASS: *nfs
+      KOPIUR_TIME: 0 15 * * *
       VOLSYNC_SNAPSHOTCLASS: *nfs
       VOLSYNC_TIME: 0 15 * * *
   prune: true

--- a/kubernetes/apps/selfhosted/changedetection/ks.yaml
+++ b/kubernetes/apps/selfhosted/changedetection/ks.yaml
@@ -14,8 +14,6 @@ spec:
       namespace: storage
     - name: kopiur
       namespace: storage
-    - name: kopiur-repository
-      namespace: storage
     - name: volsync
       namespace: storage
   interval: 30m

--- a/kubernetes/apps/selfhosted/changedetection/ks.yaml
+++ b/kubernetes/apps/selfhosted/changedetection/ks.yaml
@@ -7,9 +7,14 @@ metadata:
   namespace: &namespace selfhosted
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: dcsi-nfs
+      namespace: storage
+    - name: kopiur
+      namespace: storage
+    - name: kopiur-repository
       namespace: storage
     - name: volsync
       namespace: storage
@@ -24,6 +29,7 @@ spec:
       PVC_CLAIM: changedetection-data
       PVC_CAPACITY: 1Gi
       PVC_STORAGECLASS: &sc dcsi-nfs
+      KOPIUR_SNAPSHOTCLASS: *sc
       VOLSYNC_SNAPSHOTCLASS: *sc
   prune: true
   sourceRef:

--- a/kubernetes/apps/selfhosted/navidrome/ks.yaml
+++ b/kubernetes/apps/selfhosted/navidrome/ks.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   components:
     - ../../../../components/authentik-proxy
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: postgres-cluster
@@ -15,6 +16,10 @@ spec:
     - name: external-secrets
       namespace: security
     - name: dcsi-iscsi
+      namespace: storage
+    - name: kopiur
+      namespace: storage
+    - name: kopiur-repository
       namespace: storage
     - name: volsync
       namespace: storage
@@ -28,8 +33,11 @@ spec:
       APP_GID: "5000"
       PVC_CLAIM: navidrome-config
       PVC_CAPACITY: 5Gi
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CACHE_CAPACITY: 5Gi
       PVC_STORAGECLASS: &sc dcsi-iscsi
+      KOPIUR_SNAPSHOTCLASS: *sc
+      KOPIUR_TIME: 0 1 * * *
       VOLSYNC_SNAPSHOTCLASS: *sc
       VOLSYNC_TIME: 0 1 * * *
   prune: true

--- a/kubernetes/apps/selfhosted/navidrome/ks.yaml
+++ b/kubernetes/apps/selfhosted/navidrome/ks.yaml
@@ -19,8 +19,6 @@ spec:
       namespace: storage
     - name: kopiur
       namespace: storage
-    - name: kopiur-repository
-      namespace: storage
     - name: volsync
       namespace: storage
   interval: 30m

--- a/kubernetes/apps/selfhosted/navidrome/ks.yaml
+++ b/kubernetes/apps/selfhosted/navidrome/ks.yaml
@@ -35,7 +35,6 @@ spec:
       VOLSYNC_CACHE_CAPACITY: 5Gi
       PVC_STORAGECLASS: &sc dcsi-iscsi
       KOPIUR_SNAPSHOTCLASS: *sc
-      KOPIUR_TIME: 0 1 * * *
       VOLSYNC_SNAPSHOTCLASS: *sc
       VOLSYNC_TIME: 0 1 * * *
   prune: true

--- a/kubernetes/apps/selfhosted/opencloud/ks.yaml
+++ b/kubernetes/apps/selfhosted/opencloud/ks.yaml
@@ -16,8 +16,6 @@ spec:
       namespace: storage
     - name: kopiur
       namespace: storage
-    - name: kopiur-repository
-      namespace: storage
     - name: volsync
       namespace: storage
   interval: 30m

--- a/kubernetes/apps/selfhosted/opencloud/ks.yaml
+++ b/kubernetes/apps/selfhosted/opencloud/ks.yaml
@@ -35,7 +35,6 @@ spec:
       KOPIUR_SNAPSHOTCLASS: *sc
       VOLSYNC_SNAPSHOTCLASS: *sc
       PVC_ACCESSMODES: ReadWriteMany
-      KOPIUR_TIME: 0 13 * * *
       VOLSYNC_TIME: 0 13 * * *
   prune: true
   sourceRef:

--- a/kubernetes/apps/selfhosted/opencloud/ks.yaml
+++ b/kubernetes/apps/selfhosted/opencloud/ks.yaml
@@ -7,11 +7,16 @@ metadata:
   namespace: selfhosted
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: external-secrets
       namespace: security
     - name: dcsi-nfs
+      namespace: storage
+    - name: kopiur
+      namespace: storage
+    - name: kopiur-repository
       namespace: storage
     - name: volsync
       namespace: storage
@@ -26,10 +31,13 @@ spec:
       APP_GID: "1000"
       PVC_CLAIM: opencloud-data
       PVC_CAPACITY: &size 20Gi
+      KOPIUR_CAPACITY: *size
       VOLSYNC_CACHE_CAPACITY: *size
       PVC_STORAGECLASS: &sc dcsi-nfs
+      KOPIUR_SNAPSHOTCLASS: *sc
       VOLSYNC_SNAPSHOTCLASS: *sc
       PVC_ACCESSMODES: ReadWriteMany
+      KOPIUR_TIME: 0 13 * * *
       VOLSYNC_TIME: 0 13 * * *
   prune: true
   sourceRef:

--- a/kubernetes/apps/selfhosted/paperless/ks.yaml
+++ b/kubernetes/apps/selfhosted/paperless/ks.yaml
@@ -20,8 +20,6 @@ spec:
       namespace: storage
     - name: kopiur
       namespace: storage
-    - name: kopiur-repository
-      namespace: storage
     - name: volsync
       namespace: storage
   interval: 30m

--- a/kubernetes/apps/selfhosted/paperless/ks.yaml
+++ b/kubernetes/apps/selfhosted/paperless/ks.yaml
@@ -36,7 +36,6 @@ spec:
       VOLSYNC_CACHE_CAPACITY: 5Gi
       PVC_STORAGECLASS: &sc dcsi-nfs
       KOPIUR_SNAPSHOTCLASS: *sc
-      KOPIUR_TIME: 0 3 * * *
       VOLSYNC_SNAPSHOTCLASS: *sc
       VOLSYNC_TIME: 0 3 * * *
   prune: true

--- a/kubernetes/apps/selfhosted/paperless/ks.yaml
+++ b/kubernetes/apps/selfhosted/paperless/ks.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: &namespace selfhosted
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   dependsOn:
     - name: postgres-cluster
@@ -16,6 +17,10 @@ spec:
     - name: external-secrets
       namespace: security
     - name: dcsi-nfs
+      namespace: storage
+    - name: kopiur
+      namespace: storage
+    - name: kopiur-repository
       namespace: storage
     - name: volsync
       namespace: storage
@@ -29,8 +34,11 @@ spec:
       APP_GID: "568"
       PVC_CLAIM: paperless-data
       PVC_CAPACITY: 5Gi
+      KOPIUR_CAPACITY: 5Gi
       VOLSYNC_CACHE_CAPACITY: 5Gi
       PVC_STORAGECLASS: &sc dcsi-nfs
+      KOPIUR_SNAPSHOTCLASS: *sc
+      KOPIUR_TIME: 0 3 * * *
       VOLSYNC_SNAPSHOTCLASS: *sc
       VOLSYNC_TIME: 0 3 * * *
   prune: true


### PR DESCRIPTION
## Summary

Bootstraps Kopiur backups for apps that currently use Volsync, without changing PVC sourcing yet.

## Changes

- add `components/kopiur/backup` to app kustomizations that already include `components/volsync`
- mirror existing `VOLSYNC_*` postBuild substitutions to `KOPIUR_*`
- add `dependsOn` for `kopiur` and `kopiur-repository`

## Scope

This is step 1 of the migration:
- Volsync remains intact
- PVC restore/source behavior remains unchanged
- Kopiur begins producing parallel backups for the same apps

## Apps updated

- bazarr
- qbittorrent
- recyclarr
- vaultwarden
- changedetection
- navidrome
- opencloud
- paperless

## Validation

- edited `ks.yaml` files parse cleanly as YAML
- pre-commit YAML formatting passed during commit