### PR TITLE
feat(storage): scaffold ix-csi Flux app

### DIFF
--- a/kubernetes/apps/storage/ix-csi/app/externalsecret.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name ix-csi
+  namespace: storage
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      data:
+        API_TOKEN: "{{ .LEO_API_TOKEN }}"
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: democratic-csi

--- a/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &release ix-csi
+  namespace: storage
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ix-csi
+  dependsOn:
+    - name: snapshot-controller
+  interval: 30m
+  values:
+    nameOverride: *release
+    image:
+      repository: ghcr.io/ishioni/ix-csi
+      tag: v1.1.2
+    config:
+      truenasURL: wss://leo.ishioni.casa/api/current
+      truenasInsecure: false
+      defaultPool: SSD
+      nfsServer: leo.ishioni.casa
+      iscsiPortal: 10.1.2.2:3260
+      nvmeofPortal: 10.1.2.2:4420
+      iscsiIQNBase: iqn.2011-08.org.truenas.ctl
+    secret:
+      existingSecret:
+        name: ix-csi
+        key: API_TOKEN
+    node:
+      kubeletRootDir: /var/lib/kubelet
+      iscsiDir: /var/iscsi
+      extraEnv:
+        - name: ISCSIADM_HOST_PATH
+          value: /usr/local/sbin/iscsiadm
+    storageClasses:
+      - name: ix-iscsi
+        defaultClass: false
+        volumeBindingMode: WaitForFirstConsumer
+        parameters:
+          protocol: iscsi
+          pool: SSD
+          datasetPath: ix-csi
+          compression: LZ4
+          volblocksize: 16K
+          sparse: "true"
+          iscsi.blocksize: "4096"
+      - name: ix-nfs
+        defaultClass: false
+        volumeBindingMode: WaitForFirstConsumer
+        mountOptions: [nfsvers=4.2, nconnect=8, hard, noatime, nodiratime]
+        parameters:
+          protocol: nfs
+          pool: SSD
+          datasetPath: ix-csi
+          compression: LZ4
+          nfs.networks: 10.1.2.0/24
+      - name: ix-nvmeof
+        defaultClass: false
+        volumeBindingMode: WaitForFirstConsumer
+        parameters:
+          protocol: nvmeof
+          pool: SSD
+          datasetPath: ix-csi
+          volblocksize: 16K
+          sparse: "true"
+    volumeSnapshotClasses:
+      - name: ix-csi
+        deletionPolicy: Delete

--- a/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
           datasetPath: ix-csi
           compression: LZ4
           nfs.networks: 10.1.2.0/24
+          detachedVolumes: "true"
       - name: ix-nvmeof
         defaultClass: false
         volumeBindingMode: WaitForFirstConsumer

--- a/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
@@ -14,9 +14,6 @@ spec:
   interval: 30m
   values:
     nameOverride: *release
-    image:
-      repository: ghcr.io/ishioni/ix-csi
-      tag: v1.1.2
     config:
       truenasURL: wss://leo.ishioni.casa/api/current
       truenasInsecure: false

--- a/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
@@ -44,6 +44,7 @@ spec:
           volblocksize: 16K
           sparse: "true"
           iscsi.blocksize: "4096"
+          detachedVolumes: "true"
       - name: ix-nfs
         defaultClass: false
         volumeBindingMode: WaitForFirstConsumer
@@ -63,6 +64,7 @@ spec:
           datasetPath: ix-csi
           volblocksize: 16K
           sparse: "true"
+          detachedVolumes: "true"
     volumeSnapshotClasses:
       - name: ix-csi
         deletionPolicy: Delete

--- a/kubernetes/apps/storage/ix-csi/app/kustomization.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ix-csi
+  namespace: storage
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.1.2
+  url: oci://ghcr.io/ishioni/charts/truenas-csi

--- a/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
@@ -11,5 +11,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.3.0
+    tag: 1.3.1
   url: oci://ghcr.io/ishioni/charts/truenas-csi

--- a/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
@@ -11,5 +11,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.1.2
+    tag: 1.3.0
   url: oci://ghcr.io/ishioni/charts/truenas-csi

--- a/kubernetes/apps/storage/ix-csi/ks.yaml
+++ b/kubernetes/apps/storage/ix-csi/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ix-csi
+  namespace: &namespace storage
+spec:
+  dependsOn:
+    - name: external-secrets
+      namespace: security
+    - name: snapshot-controller
+      namespace: *namespace
+  interval: 30m
+  path: ./kubernetes/apps/storage/ix-csi/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab-ops
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/namespace
 resources:
   - ./democratic-csi/ks.yaml
+  - ./ix-csi/ks.yaml
   - ./kopiur/ks.yaml
   - ./openebs/ks.yaml
   - ./snapshot-controller/ks.yaml


### PR DESCRIPTION
## Summary

This scaffolds an ix-csi Flux app in kubernetes/apps/storage and wires its ks.yaml into the top-level storage kustomization so the full object graph is visible in review.

## What this includes

- OCIRepository for the test-published Helm chart
- HelmRelease with the currently validated Talos-specific values
- ExternalSecret for the TrueNAS API token
- ks.yaml for reconciling the app from Flux

## Status

This PR is intentionally not ready for consumption yet.

It exists so the cluster-side wiring can be reviewed in parallel while upstream work continues.

## Remaining blockers before this should actually be used

- the Helm chart should ideally be merged upstream rather than living only in the forked publishing flow
- detached snapshot and clone functionality still needs to exist in truenas-csi
- until detached restore behavior exists, restored volumes remain tied to source clone lineage, which is not the behavior I want for long-term adoption

## Notes

- this branch wires kubernetes/apps/storage/ix-csi/ks.yaml into kubernetes/apps/storage/kustomization.yaml on purpose so the PR produces a meaningful rendered diff
- that does not mean it should be merged or enabled immediately; this should wait until the overall solution is ready
