### PR TITLE
fix(renovate): allow shared artifact tasks

### DIFF
--- a/kubernetes/apps/github/renovate/jobs/renovatejob.yaml
+++ b/kubernetes/apps/github/renovate/jobs/renovatejob.yaml
@@ -11,8 +11,10 @@ spec:
   extraEnv:
     - name: LOG_LEVEL
       value: debug
+    - name: RENOVATE_ALLOWED_UNSAFE_EXECUTIONS
+      value: '["goGenerate", "mise"]'
     - name: RENOVATE_ALLOWED_COMMANDS
-      value: '["pnpm run bundle"]'
+      value: '["^helm-docs ", "^helm-schema "]'
     - name: RENOVATE_REDIS_URL
       value: redis://dragonfly.database.svc.cluster.local:6379/8
   image: ghcr.io/renovatebot/renovate:43.268.2


### PR DESCRIPTION
## Summary
- align the Renovate Operator command policy with the central Home Operations Renovate workflow
- allow trusted Helm documentation and schema artifact generation
- allow Renovate's supported Mise and Go generate operations

## Validation
- git diff --check
- YAML parsed with yq
- Lefthook format-yaml pre-commit hook