### PR TITLE
Extend vMCP session TTL for Zed

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpserver.yaml
@@ -59,10 +59,19 @@ spec:
     db: 9
     provider: redis
     keyPrefix: "vmcp-sessions:"
+  # Keep Zed's cached MCP session alive across normal periods of inactivity.
+  # Remove this override once https://github.com/zed-industries/zed/issues/57180 is fixed.
+  # podTemplateSpec replaces the container args list, so retain all operator-generated args here.
   podTemplateSpec:
     spec:
       containers:
         - name: vmcp
+          args:
+            - serve
+            - --config=/etc/vmcp-config/config.yaml
+            - --host=0.0.0.0
+            - --port=4483
+            - --session-ttl=168h
           env:
             - name: INSECURE_DISABLE_URL_VALIDATION
               value: "true"
@@ -92,3 +101,16 @@ spec:
     keyPrefix: "vmcp-sessions:"
   telemetryConfigRef:
     name: prometheus
+  # Keep Zed's cached MCP session alive across normal periods of inactivity.
+  # Remove this override once https://github.com/zed-industries/zed/issues/57180 is fixed.
+  # podTemplateSpec replaces the container args list, so retain all operator-generated args here.
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: vmcp
+          args:
+            - serve
+            - --config=/etc/vmcp-config/config.yaml
+            - --host=0.0.0.0
+            - --port=4483
+            - --session-ttl=168h


### PR DESCRIPTION
## Summary

- set a one-week sliding vMCP session TTL on both the external OIDC and internal ToolHive gateways
- retain the operator-generated container arguments when overriding `podTemplateSpec`
- document the workaround and link the upstream Zed issue

## Why

ToolHive expires inactive vMCP session metadata after 30 minutes. Zed currently retains the expired `Mcp-Session-Id`; when ToolHive correctly returns HTTP 404, Zed waits for its 60-second context-server timeout and does not reinitialize. Extending the inactivity TTL substantially reduces this failure mode until zed-industries/zed#57180 is fixed.

The external gateway's OIDC access-token and refresh-token lifetimes are unchanged. This only extends vMCP session metadata lifetime.

## Validation

- `kubectl kustomize kubernetes/apps/ai/toolhive/config`
- `git diff --check`
- repository `format-yaml` pre-commit hook