### PR TITLE
chore: migrate snapshot controller to Home Operations chart

### DIFF
--- a/kubernetes/apps/storage/snapshot-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/snapshot-controller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 5.1.1
-  url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller
+    tag: 0.1.0
+  url: oci://ghcr.io/home-operations/charts/snapshot-controller


### PR DESCRIPTION
## Summary
- migrate the snapshot-controller OCI source from Piraeus Datastore to `ghcr.io/home-operations/charts/snapshot-controller`
- pin the initial Home Operations chart release at `0.1.0`
- annotate the six installed snapshot and group-snapshot CRDs with `helm.sh/resource-policy=keep` so Helm preserves them during the migration

## Validation
- `kubectl kustomize kubernetes/apps/storage/snapshot-controller/app`
- `git diff --check`
- verified each installed snapshot CRD reports `helm.sh/resource-policy=keep` via the repository kubeconfig

The CRD annotations were applied directly to the cluster before this chart-source change.