### PR TITLE
feat(tofu-controller): use fork release v0.16.5-ishioni.1

### DIFF
--- a/kubernetes/apps/flux-system/tofu-controller/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/app/externalsecret.yaml
@@ -33,12 +33,11 @@ spec:
     creationPolicy: Owner
     template:
       data:
-        access_key: "{{ .S3_ACCESS_KEY }}"
-        secret_key: "{{ .S3_SECRET_KEY }}"
-
+        access_key: "{{ .username }}"
+        secret_key: "{{ .password }}"
   dataFrom:
     - extract:
-        key: tofu-controller
+        key: rustfs
 ---
 # yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
@@ -53,8 +52,13 @@ spec:
     name: *name
     creationPolicy: Owner
     template:
+      engineVersion: v2
+      mergePolicy: Replace
       data:
-        token: "{{ .GITHUB_TOKEN }}"
+        # The `tofu-controller` 1Password item must provide these GitHub App fields.
+        githubAppID: "{{ .APP_ID }}"
+        githubAppInstallationID: "{{ .INSTALLATION_ID }}"
+        githubAppPrivateKey: "{{ .PRIVATE_KEY }}"
   dataFrom:
     - extract:
-        key: tofu-controller
+        key: github-bot

--- a/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     awsPackage:
       install: false
-    branchPlaner:
+    branchPlanner:
       enabled: true
     metrics:
       enabled: true

--- a/kubernetes/apps/flux-system/tofu-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.16.4
-  url: oci://ghcr.io/flux-iac/charts/tofu-controller
+    tag: 0.16.5-ishioni.1
+  url: oci://ghcr.io/ishioni/charts/tofu-controller


### PR DESCRIPTION
## Summary

- switch the Tofu Controller OCI source to the forked `0.16.5-ishioni.1` chart at `ghcr.io/ishioni/charts`
- use the fork-published controller, runner, and branch-planner images through the chart defaults
- correct `branchPlaner` to `branchPlanner` so branch planning is actually enabled
- configure the branch-planner provider Secret for GitHub App authentication instead of PAT authentication

The fork release includes upstream #1808 (Kubernetes backend state Secret label selector fix) and #1843 (GitHub App authentication API base URL fix).

## GitHub App setup

Add these fields to the `tofu-controller` item in 1Password:

- `GITHUB_APP_ID` — numeric GitHub App ID
- `GITHUB_APP_INSTALLATION_ID` — numeric installation ID for the installation that can access the managed repositories
- `GITHUB_APP_PRIVATE_KEY` — PEM private key, including its line breaks

The ExternalSecret renders them as the exact keys required by tofu-controller: `githubAppID`, `githubAppInstallationID`, and `githubAppPrivateKey`. The former `token` mapping is removed, so incomplete App credentials fail clearly rather than silently falling back to PAT auth.

Install the app only on the repositories whose pull requests the planner should process. Its required repository permissions are:

- **Pull requests: Read-only** — list open pull requests and changed files
- **Issues: Read and write** — read, create, and update pull-request comments (GitHub exposes PR comments through the Issues API)

No Contents, Checks, Commit statuses, Actions, or administration permission is used by the branch planner. Flux's `GitRepository` source authentication remains separate from this GitHub App.

## Validation

- `kubectl kustomize kubernetes/apps/flux-system/tofu-controller/app`
- rendered `oci://ghcr.io/ishioni/charts/tofu-controller` version `0.16.5-ishioni.1` with these HelmRelease values; confirmed fork controller, runner, and branch-planner image references
- `go test ./internal/git/provider -run TestOptsFromSecretGitHubApp -count=1`
