### PR TITLE
feat(tofu-controller): plan rustfs

### DIFF
--- a/kubernetes/apps/flux-system/tofu-controller/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/app/externalsecret.yaml
@@ -3,46 +3,6 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &name tofu-secret
-spec:
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword
-  target:
-    name: *name
-    creationPolicy: Owner
-    template:
-      data:
-        OP_CONNECT_HOST: http://onepassword-connect.security.svc.cluster.local:8080
-        OP_CONNECT_TOKEN: "{{ .OP_CONNECT_TOKEN }}"
-  dataFrom:
-    - extract:
-        key: op-connect
----
-# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: &name tofu-s3-secret
-spec:
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword
-  target:
-    name: *name
-    creationPolicy: Owner
-    template:
-      data:
-        access_key: "{{ .username }}"
-        secret_key: "{{ .password }}"
-  dataFrom:
-    - extract:
-        key: rustfs
----
-# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
   name: &name tofu-branch-token
 spec:
   secretStoreRef:

--- a/kubernetes/apps/flux-system/tofu-controller/ks.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/ks.yaml
@@ -14,3 +14,22 @@ spec:
     kind: GitRepository
     name: homelab-ops
     namespace: flux-system
+  wait: true
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tofu-plans
+  namespace: flux-system
+spec:
+  targetNamespace: flux-system
+  dependsOn:
+    - name: tofu-controller
+  interval: 30m
+  path: ./kubernetes/apps/flux-system/tofu-controller/plans
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab-ops
+    namespace: flux-system

--- a/kubernetes/apps/flux-system/tofu-controller/plans/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/plans/externalsecret.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name tofu-op-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      data:
+        OP_CONNECT_HOST: http://onepassword-connect.security.svc.cluster.local:8080
+        OP_CONNECT_TOKEN: "{{ .OP_CONNECT_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: op-connect
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name tofu-s3-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      data:
+        AWS_S3_ENDPOINT: https://rs3.ishioni.casa
+        AWS_REGION: eu-central-1
+        AWS_ACCESS_KEY_ID: "{{ .S3_ACCESS_KEY }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .S3_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: tofu-controller

--- a/kubernetes/apps/flux-system/tofu-controller/plans/kustomization.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/plans/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./rustfs.yaml

--- a/kubernetes/apps/flux-system/tofu-controller/plans/rustfs.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/plans/rustfs.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/infra.contrib.fluxcd.io/terraform_v1alpha2.json
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: rustfs
+spec:
+  interval: 30m
+  path: ./terraform/rustfs
+  planOnly: true
+  storeReadablePlan: human
+  sourceRef:
+    kind: GitRepository
+    name: homelab-ops
+    namespace: flux-system
+  runnerPodTemplate:
+    spec:
+      envFrom:
+        - secretRef:
+            name: tofu-op-secret
+        - secretRef:
+            name: tofu-s3-secret


### PR DESCRIPTION
## Summary

- add a plan-only RustFS Terraform resource from the existing homelab-ops Flux source
- keep controller configuration and Terraform plans in separate Flux Kustomizations
- make tofu-plans depend on tofu-controller, and wait for the controller Kustomization to be ready
- keep the branch-planner GitHub App Secret with the controller
- move runner-only ExternalSecrets to tofu-plans: tofu-op-secret for the OnePassword provider and tofu-s3-secret for the S3 backend
- inject the dedicated tofu-controller S3 backend credentials as standard AWS environment variables, matching terraform/.mise.toml

## Validation

- kubectl kustomize kubernetes/apps/flux-system/tofu-controller/app
- kubectl kustomize kubernetes/apps/flux-system/tofu-controller/plans
- kubectl kustomize kubernetes/apps/flux-system
- tofu -chdir=terraform/rustfs validate
- mise exec -C terraform/rustfs -- tofu state pull
- oxfmt --check for changed YAML
- repository pre-commit format-yaml hook

The live kubectl server dry-run could not run because this workspace kubeconfig targets an unavailable localhost:8080 API server.