### PR TITLE
feat(rustfs): add branch planner test bucket

### DIFF
--- a/terraform/rustfs/branch-planner-test.tofu
+++ b/terraform/rustfs/branch-planner-test.tofu
@@ -1,0 +1,5 @@
+module "branch_planner_test" {
+  source      = "./modules/rustfs"
+  bucket_name = "branch-planner-test"
+  create_user = false
+}


### PR DESCRIPTION
## Purpose

Exercise Tofu Controller Branch Planner with an isolated RustFS change.

## Change

Adds the private branch-planner-test bucket through the existing RustFS module with create_user = false. The expected plan should contain one bucket creation and no IAM user or policy resources.

## Validation

- tofu fmt -check branch-planner-test.tofu
- repository pre-commit hook

Tofu validate could not complete because the backend-disabled tofu init timed out while initializing providers. The recursive formatter also reports a pre-existing formatting issue in terraform/rustfs/modules/rustfs/main.tofu; it is unrelated and unchanged.