### PR TITLE
fix(rustfs): use configured S3 state backend

### DIFF
--- a/kubernetes/apps/flux-system/tofu-controller/plans/rustfs.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/plans/rustfs.yaml
@@ -6,6 +6,8 @@ metadata:
   name: rustfs
 spec:
   interval: 30m
+  backendConfig:
+    disable: true
   path: ./terraform/rustfs
   planOnly: true
   storeReadablePlan: human


### PR DESCRIPTION
## Root cause

Tofu Controller injects a Kubernetes backend when spec.backendConfig is absent. Because the RustFS resource is plan-only, that injected backend has empty state and every plan proposes recreating all existing RustFS resources.

## Fix

Set backendConfig.disable: true so the controller does not create its Kubernetes backend override. OpenTofu then uses the existing S3 backend in terraform/rustfs/main.tofu with the AWS credentials injected from tofu-s3-secret.

## Expected result

After Flux reconciles this change, the base RustFS plan should use terraform/rustfs/state.tfstate and stop proposing all managed RustFS resources as additions. Re-running Branch Planner on #5457 should then plan only the test bucket.

## Validation

- kubectl kustomize kubernetes/apps/flux-system/tofu-controller/plans
- kubectl kustomize kubernetes/apps/flux-system
- oxfmt --check for the changed manifest
- repository pre-commit format-yaml hook