### PR TITLE
fix(rustfs): configure S3 backend for readable plans

### DIFF
--- a/kubernetes/apps/flux-system/tofu-controller/plans/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/plans/externalsecret.yaml
@@ -37,8 +37,6 @@ spec:
         AWS_REGION: eu-central-1
         AWS_ACCESS_KEY_ID: "{{ .S3_ACCESS_KEY }}"
         AWS_SECRET_ACCESS_KEY: "{{ .S3_SECRET_KEY }}"
-        access_key: "{{ .S3_ACCESS_KEY }}"
-        secret_key: "{{ .S3_SECRET_KEY }}"
   dataFrom:
     - extract:
         key: tofu-controller

--- a/kubernetes/apps/flux-system/tofu-controller/plans/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/plans/externalsecret.yaml
@@ -37,6 +37,8 @@ spec:
         AWS_REGION: eu-central-1
         AWS_ACCESS_KEY_ID: "{{ .S3_ACCESS_KEY }}"
         AWS_SECRET_ACCESS_KEY: "{{ .S3_SECRET_KEY }}"
+        access_key: "{{ .S3_ACCESS_KEY }}"
+        secret_key: "{{ .S3_SECRET_KEY }}"
   dataFrom:
     - extract:
         key: tofu-controller

--- a/kubernetes/apps/flux-system/tofu-controller/plans/rustfs.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/plans/rustfs.yaml
@@ -7,7 +7,27 @@ metadata:
 spec:
   interval: 30m
   backendConfig:
-    disable: true
+    customConfiguration: |
+      backend "s3" {
+        bucket                      = "terraform"
+        key                         = "rustfs/state.tfstate"
+        region                      = "eu-central-1"
+        endpoint                    = "https://rs3.ishioni.casa"
+        skip_credentials_validation = true
+        skip_metadata_api_check     = true
+        skip_region_validation      = true
+        skip_requesting_account_id  = true
+        force_path_style            = true
+        skip_s3_checksum            = true
+      }
+  backendConfigsFrom:
+    - kind: Secret
+      name: tofu-s3-secret
+      keys:
+        - access_key
+        - secret_key
+  branchPlanner:
+    enablePathScope: true
   path: ./terraform/rustfs
   planOnly: true
   storeReadablePlan: human

--- a/kubernetes/apps/flux-system/tofu-controller/plans/rustfs.yaml
+++ b/kubernetes/apps/flux-system/tofu-controller/plans/rustfs.yaml
@@ -16,16 +16,7 @@ spec:
         skip_credentials_validation = true
         skip_metadata_api_check     = true
         skip_region_validation      = true
-        skip_requesting_account_id  = true
-        force_path_style            = true
-        skip_s3_checksum            = true
       }
-  backendConfigsFrom:
-    - kind: Secret
-      name: tofu-s3-secret
-      keys:
-        - access_key
-        - secret_key
   branchPlanner:
     enablePathScope: true
   path: ./terraform/rustfs


### PR DESCRIPTION
## Supersedes #5458 backend behavior

The merged backendConfig.disable change stopped the controller from injecting Kubernetes state, but it also marks the backend as completely disabled. Tofu Controller then deliberately omits the tfplan output file, while storeReadablePlan: human still attempts to read it. This results in the observed error: open tfplan: no such file or directory.

## Fix

Configure the RustFS S3 backend through backendConfig.customConfiguration instead. This keeps a normal backend and saved tfplan output while using the populated terraform/rustfs/state.tfstate object.

The runner pod imports tofu-s3-secret with envFrom. The runner preserves its process environment when starting OpenTofu, so the S3 backend receives AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY without duplicate access_key or secret_key projections.

branchPlanner.enablePathScope remains enabled, so plans are generated only for PRs that modify terraform/rustfs.

## Safety

The resource remains planOnly: true. This PR restores successful plans; it does not enable apply.

## Validation

- kubectl kustomize kubernetes/apps/flux-system/tofu-controller/plans
- kubectl kustomize kubernetes/apps/flux-system
- oxfmt --check for changed YAML
- repository pre-commit format-yaml hook