### PR TITLE
test(rustfs): remove branch planner test bucket

### DIFF
--- a/terraform/rustfs/branch-planner-test.tofu
+++ b/terraform/rustfs/branch-planner-test.tofu
@@ -1,5 +1,0 @@
-module "branch_planner_test" {
-  source      = "./modules/rustfs"
-  bucket_name = "branch-planner-test"
-  create_user = false
-}


### PR DESCRIPTION
Removes the branch-planner-test RustFS bucket definition to verify that Tofu Controller Branch Planner produces a plan-only destroy preview.