### PR TITLE
refactor: rename dexd service

### DIFF
--- a/docker/truenas/06-dexd/docker-compose.yml
+++ b/docker/truenas/06-dexd/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 services:
-  docker-external-dns:
+  dexd:
     image: ghcr.io/ishioni/dexd:0.4.0@sha256:e645dab009d373cca6c6ee6814375cac1201755c1dfde5a5843c2c9e29ccf00e
     container_name: dexd
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Rename the TrueNAS Compose service from its deprecated name to `dexd`.

This pairs with the `dexd` breaking identity cleanup and does not change the container name, image, networking, or runtime configuration.