### PR TITLE
feat(kubernetes): deploy Frigate

### DIFF
--- a/kubernetes/apps/selfhosted/frigate/app/config/config.yml
+++ b/kubernetes/apps/selfhosted/frigate/app/config/config.yml
@@ -1,0 +1,40 @@
+---
+mqtt:
+  enabled: false
+
+database:
+  path: /config/frigate.db
+
+detectors:
+  ov:
+    type: openvino
+    device: GPU
+
+ffmpeg:
+  hwaccel_args: preset-vaapi
+
+detect:
+  enabled: true
+  fps: 5
+
+record:
+  enabled: true
+
+snapshots:
+  enabled: true
+
+cameras:
+  kids:
+    ffmpeg:
+      inputs:
+        - path: rtsp://{FRIGATE_KIDS_RTSP_USER}:{FRIGATE_KIDS_RTSP_PASSWORD}@camera-kids.ishioni.casa/live0
+          roles:
+            - detect
+            - record
+  bedroom:
+    ffmpeg:
+      inputs:
+        - path: rtsp://{FRIGATE_BEDROOM_RTSP_USER}:{FRIGATE_BEDROOM_RTSP_PASSWORD}@camera-bedroom.ishioni.casa/live0
+          roles:
+            - detect
+            - record

--- a/kubernetes/apps/selfhosted/frigate/app/config/kustomizeconfig.yaml
+++ b/kubernetes/apps/selfhosted/frigate/app/config/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/values/persistence/config-file/name
+        kind: HelmRelease

--- a/kubernetes/apps/selfhosted/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/frigate/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name frigate-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      data:
+        FRIGATE_KIDS_RTSP_USER: "{{ .KIDSCAM_RTSP_USER }}"
+        FRIGATE_KIDS_RTSP_PASSWORD: "{{ .KIDSCAM_RTSP_PASSWORD }}"
+        FRIGATE_BEDROOM_RTSP_USER: "{{ .BEDROOMCAM_RTSP_USER }}"
+        FRIGATE_BEDROOM_RTSP_PASSWORD: "{{ .BEDROOMCAM_RTSP_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: eufy

--- a/kubernetes/apps/selfhosted/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/frigate/app/helmrelease.yaml
@@ -1,0 +1,118 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: frigate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: frigate
+  interval: 30m
+  values:
+    controllers:
+      frigate:
+        pod:
+          resourceClaims:
+            - name: gpu
+              resourceClaimTemplateName: frigate-gpu
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/blakeblackshear/frigate
+              tag: 0.17.2@sha256:d4351369984d4a9e2a49ac59736f6490856a7ea11f7790040746d21496967010
+            env:
+              TZ: ${CONFIG_TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: frigate-secret
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: 5000
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              claims:
+                - name: gpu
+              requests:
+                cpu: 200m
+                memory: 2Gi
+              limits:
+                memory: 8Gi
+    service:
+      frigate:
+        controller: frigate
+        ports:
+          http:
+            appProtocol: kubernetes.io/ws
+            port: 5000
+            primary: true
+          go2rtc:
+            port: 1984
+          rtsp:
+            port: 8554
+          webrtc-tcp:
+            port: 8555
+            protocol: TCP
+          webrtc-udp:
+            port: 8555
+            protocol: UDP
+    route:
+      frigate:
+        hostnames:
+          - ${HOSTNAME}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: frigate
+                port: http
+    persistence:
+      config:
+        existingClaim: ${PVC_CLAIM}
+      config-file:
+        type: configMap
+        name: frigate-config
+        globalMounts:
+          - path: /config/config.yml
+            subPath: config.yml
+            readOnly: true
+      media:
+        existingClaim: frigate-media
+        globalMounts:
+          - path: /media/frigate
+      cache:
+        enabled: true
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 2Gi
+        globalMounts:
+          - path: /dev/shm
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          frigate:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/selfhosted/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/frigate/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./media-pvc.yaml
+  - ./ocirepository.yaml
+configMapGenerator:
+  - name: frigate-config
+    files:
+      - config.yml=./config/config.yml
+configurations:
+  - ./config/kustomizeconfig.yaml

--- a/kubernetes/apps/selfhosted/frigate/app/media-pvc.yaml
+++ b/kubernetes/apps/selfhosted/frigate/app/media-pvc.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/core/persistentvolume_v1.json
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: frigate-media
+spec:
+  capacity:
+    storage: 4000Gi
+  volumeMode: Filesystem
+  accessModes: [ReadWriteMany]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  nfs:
+    server: "${CONFIG_TRUENAS_IP}"
+    path: /mnt/HDD/Frigate
+  mountOptions: [nfsvers=4.2, nconnect=8, hard, noatime, nodiratime]
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/core/persistentvolumeclaim_v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-media
+spec:
+  accessModes: [ReadWriteMany]
+  resources:
+    requests:
+      storage: 4000Gi
+  storageClassName: nfs
+  volumeMode: Filesystem
+  volumeName: frigate-media

--- a/kubernetes/apps/selfhosted/frigate/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/frigate/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: frigate
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/bjw-s-labs/helm.*

--- a/kubernetes/apps/selfhosted/frigate/ks.yaml
+++ b/kubernetes/apps/selfhosted/frigate/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app frigate
+  namespace: &namespace selfhosted
+spec:
+  components:
+    - ../../../../components/gpu
+    - ../../../../components/kopiur
+  dependsOn:
+    - name: dcsi-iscsi
+      namespace: storage
+    - name: external-secrets
+      namespace: security
+    - name: intel-gpu-resource-driver
+      namespace: kube-system
+    - name: kopiur
+      namespace: storage
+  interval: 30m
+  path: ./kubernetes/apps/selfhosted/frigate/app
+  postBuild:
+    substitute:
+      APP: *app
+      HOSTNAME: frigate.${PRIVATE_DOMAIN}
+      PVC_CLAIM: frigate-config
+      PVC_CAPACITY: 5Gi
+      PVC_STORAGECLASS: &sc dcsi-iscsi
+      KOPIUR_SNAPSHOTCLASS: *sc
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab-ops
+    namespace: flux-system
+  targetNamespace: *namespace

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./changedetection/ks.yaml
   - ./convertx/ks.yaml
   # - ./denondashboard/ks.yaml
+  - ./frigate/ks.yaml
   - ./go2rtc/ks.yaml
   - ./immich/ks.yaml
   - ./it-tools/ks.yaml


### PR DESCRIPTION
## Summary
- deploy Frigate in the selfhosted namespace using the app-template OCI chart
- configure the kids and bedroom cameras from the existing `eufy` 1Password item
- store Frigate's SQLite database on an iSCSI-backed config PVC
- use the Kopiur component for config PVC restore, snapshots, and scheduled backups
- bind the existing Leo NFS share at `/mnt/HDD/Frigate` through a dedicated PV/PVC
- use the cluster Intel GPU/OpenVINO detector and expose Frigate/go2rtc/RTSP/WebRTC services

The media PV/PVC is intentionally not included in Kopiur backups because it is the large existing NFS recording share; Kopiur backs up the iSCSI-backed application state instead.

## Validation
- `kubectl kustomize kubernetes/apps/selfhosted/frigate/app`
- `kubectl kustomize kubernetes/apps/selfhosted`
- Helm template render with app-template `5.0.1`
- YAML parsing and Frigate config assertions
- pre-commit YAML formatter after the Kopiur change

The pinned Frigate container validation could not run because the local Docker/OrbStack socket is unavailable.
