### PR TITLE
fix(kubernetes): configure Frigate OpenVINO model

### DIFF
--- a/kubernetes/apps/selfhosted/frigate/app/config/config.yml
+++ b/kubernetes/apps/selfhosted/frigate/app/config/config.yml
@@ -10,6 +10,14 @@ detectors:
     type: openvino
     device: GPU
 
+model:
+  width: 300
+  height: 300
+  input_tensor: nhwc
+  input_pixel_format: bgr
+  path: /openvino-model/ssdlite_mobilenet_v2.xml
+  labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+
 ffmpeg:
   hwaccel_args: preset-vaapi
 


### PR DESCRIPTION
## Summary
Frigate starts the OpenVINO detector as `ov`, but the deployed configuration omitted the bundled model path. This caused the detector process to crash with:

```text
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

This adds the documented bundled SSDLite MobileNet v2 OpenVINO model configuration:

- `/openvino-model/ssdlite_mobilenet_v2.xml`
- `/openvino-model/coco_91cl_bkgr.txt`

## Validation
- Frigate `0.17.2` pinned-image config validation passed using Docker
- `kubectl kustomize kubernetes/apps/selfhosted/frigate/app` passed
- `kubectl kustomize kubernetes/apps/selfhosted` passed
- pre-commit YAML formatter passed

The read-only migration warning during validation is expected because the config is Git-managed through a ConfigMap.
