### PR TITLE
fix(kubernetes): allow Frigate Kopiur backup permissions

### DIFF
--- a/kubernetes/apps/selfhosted/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/frigate/app/helmrelease.yaml
@@ -58,6 +58,10 @@ spec:
                 memory: 2Gi
               limits:
                 memory: 8Gi
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
     service:
       frigate:
         controller: frigate

--- a/kubernetes/apps/selfhosted/frigate/ks.yaml
+++ b/kubernetes/apps/selfhosted/frigate/ks.yaml
@@ -28,6 +28,25 @@ spec:
       PVC_CAPACITY: 5Gi
       PVC_STORAGECLASS: &sc dcsi-iscsi
       KOPIUR_SNAPSHOTCLASS: *sc
+  patches:
+    - patch: |
+        apiVersion: kopiur.home-operations.com/v1alpha1
+        kind: SnapshotPolicy
+        metadata:
+          name: frigate
+          annotations:
+            kopiur.home-operations.com/allow-identity-change: "true"
+        spec:
+          mover:
+            inheritSecurityContextFrom:
+              pvcConsumer:
+                container: app
+            securityContext:
+              runAsNonRoot: false
+      target:
+        group: kopiur.home-operations.com
+        version: v1alpha1
+        kind: SnapshotPolicy
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
The initial Frigate Kopiur snapshot reached the CSI snapshot stage successfully but the mover failed with:

```text
kopiaErrorClass: PermissionDenied
unable to open /pvc/frigate-config/.jwt_secret: permission denied
```

Frigate runs as root and creates `.jwt_secret` with mode `0600`, while the default Kopiur mover runs as `568:568`.

This change:

- pins Frigate's pod identity to `0:0` explicitly;
- makes the Frigate SnapshotPolicy inherit the identity from its PVC consumer;
- allows the identity change for this policy only;
- disables the mover's default `runAsNonRoot` constraint for this policy only.

Other Kopiur policies remain unchanged and non-root.

## Validation
- rendered the app plus local GPU/Kopiur components with Kustomize
- confirmed the generated SnapshotPolicy contains the identity inheritance and override
- confirmed the Helm render pins Frigate to UID/GID `0:0`
- pre-commit YAML formatter passed

After merge, the failed snapshot should be retried/recreated and the generated mover Job should run with the Frigate consumer identity.
