### PR TITLE
fix(kubernetes): apply Frigate Kopiur identity component

### DIFF
--- a/kubernetes/apps/selfhosted/frigate/ks.yaml
+++ b/kubernetes/apps/selfhosted/frigate/ks.yaml
@@ -28,25 +28,9 @@ spec:
       PVC_CAPACITY: 5Gi
       PVC_STORAGECLASS: &sc dcsi-iscsi
       KOPIUR_SNAPSHOTCLASS: *sc
-  patches:
-    - patch: |
-        apiVersion: kopiur.home-operations.com/v1alpha1
-        kind: SnapshotPolicy
-        metadata:
-          name: frigate
-          annotations:
-            kopiur.home-operations.com/allow-identity-change: "true"
-        spec:
-          mover:
-            inheritSecurityContextFrom:
-              pvcConsumer:
-                container: app
-            securityContext:
-              runAsNonRoot: false
-      target:
-        group: kopiur.home-operations.com
-        version: v1alpha1
-        kind: SnapshotPolicy
+      KOPIUR_MOVER_UID: "0"
+      KOPIUR_MOVER_GID: "0"
+      KOPIUR_MOVER_NON_ROOT: "false"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/components/kopiur/restore.yaml
+++ b/kubernetes/components/kopiur/restore.yaml
@@ -9,9 +9,13 @@ spec:
     enabled: true
   mover:
     podSecurityContext:
-      runAsUser: ${APP_UID:=568}
-      runAsGroup: ${APP_GID:=568}
-      fsGroup: ${APP_GID:=568}
+      runAsUser: ${KOPIUR_MOVER_UID:=${APP_UID:=568}}
+      runAsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+      fsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+    securityContext:
+      runAsUser: ${KOPIUR_MOVER_UID:=${APP_UID:=568}}
+      runAsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+      runAsNonRoot: ${KOPIUR_MOVER_NON_ROOT:=true}
   policy:
     onMissingSnapshot: Continue
   source:

--- a/kubernetes/components/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/snapshotpolicy.yaml
@@ -11,9 +11,13 @@ spec:
     compressor: zstd
   mover:
     podSecurityContext:
-      runAsUser: ${APP_UID:=568}
-      runAsGroup: ${APP_GID:=568}
-      fsGroup: ${APP_GID:=568}
+      runAsUser: ${KOPIUR_MOVER_UID:=${APP_UID:=568}}
+      runAsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+      fsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+    securityContext:
+      runAsUser: ${KOPIUR_MOVER_UID:=${APP_UID:=568}}
+      runAsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+      runAsNonRoot: ${KOPIUR_MOVER_NON_ROOT:=true}
   repository:
     kind: ClusterRepository
     name: leo


### PR DESCRIPTION
## Summary
The merged Frigate Kopiur fix did not reach the live `SnapshotPolicy` because the parent Flux Kustomization replaces the `spec.patches` list. The mover therefore continued to run as `568:568` and could not read Frigate's root-only `/config/.jwt_secret` (`0:568`, mode `0600`).

This updates the shared `components/kopiur` component instead of adding a Frigate-specific component:

- adds generic `KOPIUR_MOVER_UID` and `KOPIUR_MOVER_GID` substitutions;
- adds generic `KOPIUR_MOVER_NON_ROOT` support;
- applies the mover security context to both backup and restore resources;
- preserves existing application UID/GID defaults for all current apps;
- configures Frigate through `ks.yaml` with mover UID/GID `0:0` and `KOPIUR_MOVER_NON_ROOT=false`.

## Validation
- rendered the Frigate app with GPU and Kopiur components using Kustomize;
- confirmed the mover fields render with the generic substitutions;
- confirmed the Frigate Helm render pins the application to UID/GID `0:0`;
- pre-commit YAML formatter passed.
