### PR TITLE
fix(kubernetes): protect Frigate behind login

### DIFF
--- a/kubernetes/apps/selfhosted/frigate/app/config/config.yml
+++ b/kubernetes/apps/selfhosted/frigate/app/config/config.yml
@@ -2,6 +2,12 @@
 mqtt:
   enabled: false
 
+auth:
+  enabled: true
+
+tls:
+  enabled: false
+
 database:
   path: /config/frigate.db
 

--- a/kubernetes/apps/selfhosted/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/frigate/app/helmrelease.yaml
@@ -70,6 +70,8 @@ spec:
             appProtocol: kubernetes.io/ws
             port: 5000
             primary: true
+          auth:
+            port: 8971
           go2rtc:
             port: 1984
           rtsp:
@@ -91,7 +93,7 @@ spec:
         rules:
           - backendRefs:
               - identifier: frigate
-                port: http
+                port: auth
     persistence:
       config:
         existingClaim: ${PVC_CLAIM}


### PR DESCRIPTION
## Summary
Frigate was being served through its internal unauthenticated port `5000`, so `frigate.ishioni.casa` opened directly to the cameras.

This change:

- explicitly enables Frigate authentication;
- disables TLS on Frigate's internal `8971` listener because Envoy terminates HTTPS at the Gateway;
- exposes Service port `8971`;
- points the HTTPRoute at the authenticated `8971` port instead of unauthenticated `5000`.

Frigate will generate the initial admin password in its logs on first authenticated startup.

## Validation
- pinned Frigate image config validation passed
- app and aggregate Kustomize builds passed
- Helm render confirmed Service port `8971` and HTTPRoute backend port `8971`
- pre-commit YAML formatter passed
