### PR TITLE
feat(kubernetes): protect Frigate with Authentik

### DIFF
--- a/kubernetes/apps/selfhosted/frigate/app/config/config.yml
+++ b/kubernetes/apps/selfhosted/frigate/app/config/config.yml
@@ -3,7 +3,19 @@ mqtt:
   enabled: false
 
 auth:
-  enabled: true
+  enabled: false
+  trusted_proxies:
+    - 172.16.0.0/16
+
+proxy:
+  header_map:
+    user: X-authentik-username
+    role: X-authentik-groups
+  role_map:
+    admin:
+      - infrastructure
+  separator: "|"
+  default_role: viewer
 
 tls:
   enabled: false

--- a/kubernetes/apps/selfhosted/frigate/ks.yaml
+++ b/kubernetes/apps/selfhosted/frigate/ks.yaml
@@ -9,6 +9,7 @@ spec:
   components:
     - ../../../../components/gpu
     - ../../../../components/kopiur
+    - ../../../../components/authentik-proxy
   dependsOn:
     - name: dcsi-iscsi
       namespace: storage

--- a/terraform/authentik/applications.tofu
+++ b/terraform/authentik/applications.tofu
@@ -140,6 +140,19 @@ module "proxy-bazarr" {
   ignore_paths       = local.favicons.bazaar
 }
 
+module "proxy-frigate" {
+  source             = "./modules/proxy_application"
+  name               = "Frigate"
+  description        = "Camera surveillance"
+  icon_url           = "https://raw.githubusercontent.com/blakeblackshear/frigate/refs/heads/dev/web/images/branding/apple-touch-icon.png"
+  group              = "Infrastructure"
+  slug               = "frigate"
+  domain             = var.private_domain
+  authorization_flow = resource.authentik_flow.provider-authorization-implicit-consent.uuid
+  invalidation_flow  = resource.authentik_flow.provider-invalidation.uuid
+  auth_groups        = [authentik_group.infrastructure.id]
+}
+
 # OAuth apps
 
 # module "oauth2-qui" {


### PR DESCRIPTION
## Summary
- protect Frigate with the shared Authentik forward-auth component
- add the Frigate proxy application to Authentik Terraform using the existing infrastructure group and branding icon
- disable Frigate native auth and map Authentik identity/group headers to Frigate roles
- trust the cluster pod CIDR for forwarded client IP handling

Users in the Authentik infrastructure group receive the Frigate admin role; other authenticated users default to viewer.

## Validation
- tofu validate
- Flux Kustomization build
- kubectl kustomize app build
- lefthook YAML formatting hook