### PR TITLE
refactor(kubernetes): localize namespace manifests

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: ai
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./context7-mcp/ks.yaml
   - ./flux-operator-mcp/ks.yaml
   - ./github-mcp/ks.yaml

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: ai
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 namespace: database
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./cloudnative-pg/ks.yaml
   - ./dragonfly/ks.yaml

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: database
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 namespace: default
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./homepage/ks.yaml
   - ./whoami/ks.yaml

--- a/kubernetes/apps/default/namespace.yaml
+++ b/kubernetes/apps/default/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: default
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/default/namespace.yaml
+++ b/kubernetes/apps/default/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: downloads
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./bazarr/ks.yaml
   - ./downloads-pvc/ks.yaml
   - ./lidarr/ks.yaml

--- a/kubernetes/apps/downloads/namespace.yaml
+++ b/kubernetes/apps/downloads/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: downloads
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/downloads/namespace.yaml
+++ b/kubernetes/apps/downloads/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: downloads
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: flux-system
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./flux-operator/ks.yaml
   - ./flux-instance/ks.yaml
   - ./tofu-controller/ks.yaml

--- a/kubernetes/apps/flux-system/namespace.yaml
+++ b/kubernetes/apps/flux-system/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: flux-system
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/flux-system/namespace.yaml
+++ b/kubernetes/apps/flux-system/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -5,5 +5,5 @@ kind: Kustomization
 namespace: games
 components:
   - ../../components/alerts
-  - ../../components/namespace
-resources: []
+resources:
+  - ./namespace.yaml

--- a/kubernetes/apps/games/namespace.yaml
+++ b/kubernetes/apps/games/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: games
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/games/namespace.yaml
+++ b/kubernetes/apps/games/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: games
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/github/kustomization.yaml
+++ b/kubernetes/apps/github/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: github
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./arc/ks.yaml
   - ./konflate/ks.yaml
   - ./kubernetes-schemas/ks.yaml

--- a/kubernetes/apps/github/namespace.yaml
+++ b/kubernetes/apps/github/namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: not-used
+  name: github
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
   labels:

--- a/kubernetes/apps/github/namespace.yaml
+++ b/kubernetes/apps/github/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: github
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: kube-system
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./cilium/ks.yaml
   - ./descheduler/ks.yaml
   - ./intel-gpu-resource-driver/ks.yaml

--- a/kubernetes/apps/kube-system/namespace.yaml
+++ b/kubernetes/apps/kube-system/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: kube-system
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/kube-system/namespace.yaml
+++ b/kubernetes/apps/kube-system/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/monitor/kustomization.yaml
+++ b/kubernetes/apps/monitor/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: monitor
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./drm-exporter/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana-operator/ks.yaml

--- a/kubernetes/apps/monitor/namespace.yaml
+++ b/kubernetes/apps/monitor/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitor
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: network
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./cdn-proxy/ks.yaml
   - ./cert-manager/ks.yaml
   - ./envoy-gateway/ks.yaml

--- a/kubernetes/apps/network/namespace.yaml
+++ b/kubernetes/apps/network/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: network
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/network/namespace.yaml
+++ b/kubernetes/apps/network/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: network
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: security
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./authentik/ks.yaml
   - ./external-secrets/ks.yaml
   - ./onepassword/ks.yaml

--- a/kubernetes/apps/security/namespace.yaml
+++ b/kubernetes/apps/security/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: security
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/security/namespace.yaml
+++ b/kubernetes/apps/security/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: security
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: selfhosted
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./atuin/ks.yaml
   - ./blog/ks.yaml
   - ./changedetection/ks.yaml

--- a/kubernetes/apps/selfhosted/namespace.yaml
+++ b/kubernetes/apps/selfhosted/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: selfhosted
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/selfhosted/namespace.yaml
+++ b/kubernetes/apps/selfhosted/namespace.yaml
@@ -5,5 +5,6 @@ metadata:
   name: selfhosted
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    kopiur.home-operations.com/privileged-movers: "true"
   labels:
     resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -5,8 +5,8 @@ kind: Kustomization
 namespace: storage
 components:
   - ../../components/alerts
-  - ../../components/namespace
 resources:
+  - ./namespace.yaml
   - ./democratic-csi/ks.yaml
   - ./kopiur/ks.yaml
   - ./openebs/ks.yaml

--- a/kubernetes/apps/storage/namespace.yaml
+++ b/kubernetes/apps/storage/namespace.yaml
@@ -5,5 +5,3 @@ metadata:
   name: storage
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-  labels:
-    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/storage/namespace.yaml
+++ b/kubernetes/apps/storage/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: storage
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/components/namespace/kustomization.yaml
+++ b/kubernetes/components/namespace/kustomization.yaml
@@ -1,6 +1,0 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.config.k8s.io/kustomization_v1beta1.json
-apiVersion: kustomize.config.k8s.io/v1alpha1
-kind: Component
-resources:
-  - ./namespace.yaml


### PR DESCRIPTION
## Summary
- replace the shared namespace component with a `namespace.yaml` in each app-group directory
- preserve the existing Flux prune-protection annotation and admin-access label for every namespace
- register each local namespace manifest in its app-group Kustomization

## Validation
- `kubectl kustomize` for all 13 affected app-group directories
- pre-commit `format-yaml` hook
