### PR TITLE
feat(kopiur): back up slskd configuration

### DIFF
--- a/kubernetes/apps/downloads/slskd/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/slskd/app/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml

--- a/kubernetes/apps/downloads/slskd/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/downloads/slskd/app/snapshotpolicy.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: ${APP}
+spec:
+  credentialProjection:
+    enabled: true
+  compression:
+    compressor: zstd
+  mover:
+    podSecurityContext:
+      runAsUser: ${KOPIUR_MOVER_UID:=${APP_UID:=568}}
+      runAsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+      fsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+    securityContext:
+      runAsUser: ${KOPIUR_MOVER_UID:=${APP_UID:=568}}
+      runAsGroup: ${KOPIUR_MOVER_GID:=${APP_GID:=568}}
+      runAsNonRoot: ${KOPIUR_MOVER_NON_ROOT:=true}
+  repository:
+    kind: ClusterRepository
+    name: leo
+  retention:
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: ${PVC_CLAIM:=${APP}}
+  volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=dcsi-iscsi}

--- a/kubernetes/apps/downloads/slskd/app/snapshotschedule.yaml
+++ b/kubernetes/apps/downloads/slskd/app/snapshotschedule.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: ${APP}
+spec:
+  policyRef:
+    name: ${APP}
+  schedule:
+    cron: ${KOPIUR_TIME:=H H * * *}
+    runOnCreate: true

--- a/kubernetes/apps/downloads/slskd/ks.yaml
+++ b/kubernetes/apps/downloads/slskd/ks.yaml
@@ -10,16 +10,23 @@ spec:
     - ../../../../components/authentik-proxy
     - ../../../../components/pvc
   dependsOn:
+    - name: dcsi-iscsi
+      namespace: storage
     - name: external-secrets
       namespace: security
+    - name: kopiur
+      namespace: storage
   interval: 30m
   path: ./kubernetes/apps/downloads/slskd/app
   postBuild:
     substitute:
       APP: *app
       APP_UID: "1000"
+      APP_GID: "5000"
       HOSTNAME: slskd.${PUBLIC_DOMAIN}
       PVC_CLAIM: slskd-config
+      PVC_STORAGECLASS: &sc dcsi-iscsi
+      KOPIUR_SNAPSHOTCLASS: *sc
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- add a Kopiur `SnapshotPolicy` and daily `SnapshotSchedule` alongside the slskd application manifests
- preserve the existing `slskd-config` PVC; this PR does not add a Restore or alter the PVC data source
- configure the Kopiur mover with slskd's existing `1000:5000` ownership and use the current `dcsi-iscsi` snapshot class

## Validation
- `just kube render-local-ks downloads slskd`
- `lefthook run pre-commit`
- `git diff master...HEAD --check`

This is preparatory backup onboarding for the later CSI migration. The subsequent migration will create a fresh restore against a verified snapshot and move the PVC to `ix-nvmeof`.