### PR TITLE
chore(storage): tear down democratic-csi workloads

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -7,12 +7,12 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
-  - ./bazarr/ks.yaml
+  # - ./bazarr/ks.yaml
   - ./downloads-pvc/ks.yaml
-  - ./lidarr/ks.yaml
+  # - ./lidarr/ks.yaml
   - ./prowlarr/ks.yaml
-  - ./qbittorrent/ks.yaml
-  - ./radarr/ks.yaml
-  - ./recyclarr/ks.yaml
-  - ./slskd/ks.yaml
-  - ./sonarr/ks.yaml
+  # - ./qbittorrent/ks.yaml
+  # - ./radarr/ks.yaml
+  # - ./recyclarr/ks.yaml
+  # - ./slskd/ks.yaml
+  # - ./sonarr/ks.yaml

--- a/kubernetes/apps/monitor/kustomization.yaml
+++ b/kubernetes/apps/monitor/kustomization.yaml
@@ -10,10 +10,10 @@ resources:
   - ./drm-exporter/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana-operator/ks.yaml
-  - ./kromgo/ks.yaml
-  - ./kube-prometheus-stack/ks.yaml
+  # - ./kromgo/ks.yaml
+  # - ./kube-prometheus-stack/ks.yaml
   - ./nut-exporter/ks.yaml
   - ./smartctl-exporter/ks.yaml
   - ./speedtest-exporter/ks.yaml
-  - ./thanos/ks.yaml
+  # - ./thanos/ks.yaml
   - ./unpoller/ks.yaml

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - ./authentik/ks.yaml
   - ./external-secrets/ks.yaml
   - ./onepassword/ks.yaml
-  - ./vaultwarden/ks.yaml
+  # - ./vaultwarden/ks.yaml

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -9,15 +9,15 @@ resources:
   - ./namespace.yaml
   - ./atuin/ks.yaml
   - ./blog/ks.yaml
-  - ./changedetection/ks.yaml
+  # - ./changedetection/ks.yaml
   - ./convertx/ks.yaml
   - ./go2rtc/ks.yaml
-  - ./immich/ks.yaml
+  # - ./immich/ks.yaml
   - ./it-tools/ks.yaml
   - ./meshmonitor/ks.yaml
-  - ./navidrome/ks.yaml
-  - ./opencloud/ks.yaml
-  - ./paperless/ks.yaml
+  # - ./navidrome/ks.yaml
+  # - ./opencloud/ks.yaml
+  # - ./paperless/ks.yaml
   - ./resume/ks.yaml
   - ./searxng/ks.yaml
   - ./selfhosted-pvc/ks.yaml


### PR DESCRIPTION
## Phase 1 of the democratic-csi migration

Remove the affected application Kustomizations from their parent resource lists so Flux tears down the old workloads and their democratic-csi claims. No StorageClass or driver configuration changes are included here.

### Removed Kustomizations

- **downloads:** bazarr, lidarr, qbittorrent, radarr, recyclarr, slskd, sonarr
- **selfhosted:** changedetection, immich, navidrome, opencloud, paperless
- **monitor:** kube-prometheus-stack and thanos
- **security:** vaultwarden
- **dependency teardown:** kromgo, because it depends on `kube-prometheus-stack`

### Deliberately retained

- `democratic-csi`, `ix-csi`, Kopiur, and the snapshot controller
- `downloads-pvc` and `selfhosted-pvc` (static `nfs` volumes, not democratic-csi)
- prowlarr and meshmonitor (no declared dependency on a removed Kustomization; meshmonitor has no rendered/live PVC)

The completed Kopiur snapshots remain available in the Kopia repository after their in-cluster `Snapshot` resources are removed. A phase-2 PR will restore the applications against ix-csi after teardown completes.

## Validation

- `lefthook run pre-commit`
- `git diff master...HEAD --check`
- YAML diagnostics are clean for all four edited files

`kustomize build` could not be run because the standalone `kustomize` binary is not installed in this environment.