### PR TITLE
feat(storage): restore unprotected ix-csi workloads

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -9,10 +9,10 @@ resources:
   - ./namespace.yaml
   # - ./bazarr/ks.yaml
   - ./downloads-pvc/ks.yaml
-  # - ./lidarr/ks.yaml
+  - ./lidarr/ks.yaml
   - ./prowlarr/ks.yaml
-  # - ./qbittorrent/ks.yaml
-  # - ./radarr/ks.yaml
+  - ./qbittorrent/ks.yaml
+  - ./radarr/ks.yaml
   # - ./recyclarr/ks.yaml
   # - ./slskd/ks.yaml
-  # - ./sonarr/ks.yaml
+  - ./sonarr/ks.yaml

--- a/kubernetes/apps/downloads/lidarr/ks.yaml
+++ b/kubernetes/apps/downloads/lidarr/ks.yaml
@@ -14,7 +14,7 @@ spec:
       namespace: database
     - name: external-secrets
       namespace: security
-    - name: dcsi-nfs
+    - name: ix-csi
       namespace: storage
   interval: 30m
   path: ./kubernetes/apps/downloads/lidarr/app
@@ -24,7 +24,7 @@ spec:
       HOSTNAME: music.${PUBLIC_DOMAIN}
       PVC_CAPACITY: 5Gi
       PVC_CLAIM: lidarr-config
-      PVC_STORAGECLASS: dcsi-nfs
+      PVC_STORAGECLASS: ix-nfs
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -10,7 +10,7 @@ spec:
     - ../../../../components/authentik-proxy
     - ../../../../components/kopiur
   dependsOn:
-    - name: dcsi-nfs
+    - name: ix-csi
       namespace: storage
     - name: kopiur
       namespace: storage
@@ -23,8 +23,8 @@ spec:
       APP_GID: "5000"
       HOSTNAME: torrent.${PUBLIC_DOMAIN}
       PVC_CLAIM: qbittorrent-config
-      PVC_STORAGECLASS: &sc dcsi-nfs
-      KOPIUR_SNAPSHOTCLASS: *sc
+      PVC_STORAGECLASS: ix-nfs
+      KOPIUR_SNAPSHOTCLASS: ix-csi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/radarr/ks.yaml
+++ b/kubernetes/apps/downloads/radarr/ks.yaml
@@ -14,7 +14,7 @@ spec:
       namespace: database
     - name: external-secrets
       namespace: security
-    - name: dcsi-nfs
+    - name: ix-csi
       namespace: storage
   interval: 30m
   path: ./kubernetes/apps/downloads/radarr/app
@@ -23,7 +23,7 @@ spec:
       APP: *app
       HOSTNAME: movies.${PUBLIC_DOMAIN}
       PVC_CLAIM: radarr-config
-      PVC_STORAGECLASS: dcsi-nfs
+      PVC_STORAGECLASS: ix-nfs
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/downloads/sonarr/ks.yaml
+++ b/kubernetes/apps/downloads/sonarr/ks.yaml
@@ -14,7 +14,7 @@ spec:
       namespace: database
     - name: external-secrets
       namespace: security
-    - name: dcsi-nfs
+    - name: ix-csi
       namespace: storage
   interval: 30m
   path: ./kubernetes/apps/downloads/sonarr/app
@@ -23,7 +23,7 @@ spec:
       APP: *app
       HOSTNAME: tv.${PUBLIC_DOMAIN}
       PVC_CLAIM: sonarr-config
-      PVC_STORAGECLASS: dcsi-nfs
+      PVC_STORAGECLASS: ix-nfs
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/monitor/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitor/kube-prometheus-stack/app/helmrelease.yaml
@@ -89,7 +89,7 @@ spec:
         storage:
           volumeClaimTemplate:
             spec:
-              storageClassName: dcsi-iscsi
+              storageClassName: ix-nvmeof
               resources:
                 requests:
                   storage: 1Gi
@@ -138,7 +138,7 @@ spec:
         storageSpec:
           volumeClaimTemplate:
             spec:
-              storageClassName: dcsi-iscsi
+              storageClassName: ix-nvmeof
               resources:
                 requests:
                   storage: 10Gi

--- a/kubernetes/apps/monitor/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/monitor/kube-prometheus-stack/ks.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: &namespace monitor
 spec:
   dependsOn:
-    - name: dcsi-iscsi
+    - name: ix-csi
       namespace: storage
     - name: external-secrets
       namespace: security

--- a/kubernetes/apps/monitor/kustomization.yaml
+++ b/kubernetes/apps/monitor/kustomization.yaml
@@ -10,10 +10,10 @@ resources:
   - ./drm-exporter/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana-operator/ks.yaml
-  # - ./kromgo/ks.yaml
-  # - ./kube-prometheus-stack/ks.yaml
+  - ./kromgo/ks.yaml
+  - ./kube-prometheus-stack/ks.yaml
   - ./nut-exporter/ks.yaml
   - ./smartctl-exporter/ks.yaml
   - ./speedtest-exporter/ks.yaml
-  # - ./thanos/ks.yaml
+  - ./thanos/ks.yaml
   - ./unpoller/ks.yaml

--- a/kubernetes/apps/monitor/thanos/app/helmrelease.yaml
+++ b/kubernetes/apps/monitor/thanos/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
         - --downsampling.disable
       persistence:
         enabled: true
-        storageClass: dcsi-iscsi
+        storageClass: ix-nvmeof
         size: 60Gi
     # query:
     #   extraArgs: --alert.query-url=http://thanos.${PUBLIC_DOMAIN}

--- a/kubernetes/apps/monitor/thanos/ks.yaml
+++ b/kubernetes/apps/monitor/thanos/ks.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: &namespace monitor
 spec:
   dependsOn:
-    - name: dcsi-iscsi
+    - name: ix-csi
       namespace: storage
     - name: external-secrets
       namespace: security

--- a/kubernetes/apps/selfhosted/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/immich/app/helmrelease.yaml
@@ -269,7 +269,7 @@ spec:
         suffix: mlcache
         size: 10Gi
         accessMode: ReadWriteMany
-        storageClass: dcsi-nfs
+        storageClass: ix-nfs
         type: persistentVolumeClaim
         advancedMounts:
           machine-learning:

--- a/kubernetes/apps/selfhosted/immich/ks.yaml
+++ b/kubernetes/apps/selfhosted/immich/ks.yaml
@@ -15,7 +15,7 @@ spec:
       namespace: database
     - name: external-secrets
       namespace: security
-    - name: dcsi-nfs
+    - name: ix-csi
       namespace: storage
     - name: intel-gpu-resource-driver
       namespace: kube-system

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
   # - ./changedetection/ks.yaml
   - ./convertx/ks.yaml
   - ./go2rtc/ks.yaml
-  # - ./immich/ks.yaml
+  - ./immich/ks.yaml
   - ./it-tools/ks.yaml
   - ./meshmonitor/ks.yaml
   # - ./navidrome/ks.yaml

--- a/kubernetes/components/kopiur/pvc.yaml
+++ b/kubernetes/components/kopiur/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ${PVC_CLAIM:=${APP}}
 spec:
   accessModes: ["${PVC_ACCESSMODES:=ReadWriteOnce}"]
-  storageClassName: ${PVC_STORAGECLASS:=dcsi-iscsi}
+  storageClassName: ${PVC_STORAGECLASS:=ix-nvmeof}
   resources:
     requests:
       storage: ${PVC_CAPACITY:=1Gi}

--- a/kubernetes/components/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/snapshotpolicy.yaml
@@ -26,4 +26,4 @@ spec:
   sources:
     - pvc:
         name: ${PVC_CLAIM:=${APP}}
-  volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=dcsi-iscsi}
+  volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=ix-csi}

--- a/kubernetes/components/pvc/pvc.yaml
+++ b/kubernetes/components/pvc/pvc.yaml
@@ -2,12 +2,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    kustomize.toolkit.fluxcd.io/prune: disabled
   name: ${PVC_CLAIM:-${APP}}
 spec:
   accessModes: ["${PVC_ACCESSMODES:-ReadWriteOnce}"]
-  storageClassName: ${PVC_STORAGECLASS:-dcsi-iscsi}
+  storageClassName: ${PVC_STORAGECLASS:-ix-nvmeof}
   resources:
     requests:
       storage: ${PVC_CAPACITY:-1Gi}


### PR DESCRIPTION
## Restore batch: workloads without Kopiur data + required dependency

Re-enable clean workloads on ix-csi after the democratic-csi teardown.

### Restored workloads

| Workload | Target |
| --- | --- |
| Lidarr, Radarr, Sonarr | fresh `ix-nfs` PVCs |
| qBittorrent | Kopiur restore to `ix-nfs` |
| Immich ML cache | fresh `ix-nfs` PVC |
| Prometheus and Alertmanager | fresh `ix-nvmeof` PVCs |
| Thanos compactor | fresh `ix-nvmeof` PVC |
| Kromgo | re-enabled with kube-prometheus-stack |

qBittorrent is intentionally included despite being backed: all three Arr HelmReleases depend on it. Thanos and Kromgo remain gated on kube-prometheus-stack through their existing dependencies.

The static `immich-data` NFS PV/PVC is unchanged; only the ML cache switches CSI drivers.

### Shared component changes

- remove `kustomize.toolkit.fluxcd.io/prune: disabled` from `components/pvc`
- default generic PVCs to `ix-nvmeof`
- default Kopiur PVCs and snapshot policies to `ix-nvmeof` / `ix-csi`

## Validation

- `just kube render-local-ks downloads qbittorrent`
- `just kube render-local-ks downloads lidarr`
- `just kube render-local-ks downloads radarr`
- `just kube render-local-ks downloads sonarr`
- `just kube render-local-ks monitor kube-prometheus-stack`
- `just kube render-local-ks monitor thanos`
- `just kube render-local-ks selfhosted immich`
- `lefthook run pre-commit`
- `git diff master...HEAD --check`