### PR TITLE
fix(storage): configure ix-csi descriptions and metrics

### DIFF
--- a/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
@@ -26,6 +26,17 @@ spec:
       existingSecret:
         name: ix-csi
         key: API_TOKEN
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+      dashboards:
+        enabled: true
+        annotations:
+          grafana_folder: Storage
+      grafanaDashboard:
+        enabled: true
+        folder: Storage
     node:
       kubeletRootDir: /var/lib/kubelet
       iscsiDir: /var/iscsi
@@ -45,6 +56,7 @@ spec:
           nfs.networks: 10.1.2.0/24
           nfs.rootSquash: "false"
           detachedVolumes: "true"
+          datasetDescription: "{{ .pvc.namespace }}/{{ .pvc.name }}"
       - name: ix-nvmeof
         defaultClass: false
         volumeBindingMode: WaitForFirstConsumer
@@ -55,6 +67,7 @@ spec:
           volblocksize: 16K
           sparse: "true"
           detachedVolumes: "true"
+          datasetDescription: "{{ .pvc.namespace }}/{{ .pvc.name }}"
     volumeSnapshotClasses:
       - name: ix-csi
         deletionPolicy: Delete

--- a/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
@@ -11,5 +11,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.4.0
+    tag: 1.5.0
   url: oci://ghcr.io/ishioni/charts/truenas-csi


### PR DESCRIPTION
## Summary

Configure the ix-csi 1.5.0 deployment with functionality missing from the existing homelab release:

- Set TrueNAS dataset descriptions to `<namespace>/<pvc-name>` for both StorageClasses.
- Enable driver and CSI sidecar metrics plus the Prometheus Operator ServiceMonitor.
- Enable the Grafana dashboard ConfigMap and Grafana Operator dashboard in the `Storage` folder.

This is a deployment configuration fix, not a new feature in homelab-ops.