### PR TITLE
fix(container): update ix-csi to 1.5.2

### DIFF
--- a/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
@@ -11,5 +11,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.5.1
+    tag: 1.5.2
   url: oci://ghcr.io/ishioni/charts/truenas-csi


### PR DESCRIPTION
## Summary

Update the ix-csi OCI chart from `1.5.1` to `1.5.2`.

This patch release contains the metrics Service port-name fix required for the deployment to reconcile successfully.