### PR TITLE
fix(storage): update ix-csi to 1.5.3

### DIFF
--- a/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
@@ -36,7 +36,15 @@ spec:
           grafana_folder: Storage
       grafanaDashboard:
         enabled: true
+        allowCrossNamespaceImport: true
+        datasources:
+          - datasourceName: prometheus
+            inputName: DS_PROMETHEUS
         folder: Storage
+        resyncPeriod: 10m
+        instanceSelector:
+          matchLabels:
+            grafana.internal/instance: grafana
     node:
       kubeletRootDir: /var/lib/kubelet
       iscsiDir: /var/iscsi

--- a/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/ocirepository.yaml
@@ -11,5 +11,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.5.2
+    tag: 1.5.3
   url: oci://ghcr.io/ishioni/charts/truenas-csi


### PR DESCRIPTION
## Summary

Update the ix-csi OCI chart from `1.5.2` to `1.5.3` and explicitly configure the Grafana Operator dashboard integration.

## Changes

- Bump the OCIRepository tag to `1.5.3`.
- Enable cross-namespace GrafanaDashboard imports.
- Configure the Prometheus datasource mapping.
- Set the Grafana Operator resync period to `10m`.
- Select the homelab Grafana instance via `grafana.internal/instance: grafana`.
- Keep the dashboard in the `Storage` folder.

The `1.5.3` chart includes the corresponding GrafanaDashboard resource fix from ix-csi PR #31.