### PR TITLE
chore: disable ix-csi consumers

### DIFF
--- a/kubernetes/apps/downloads/bazarr/ks.yaml
+++ b/kubernetes/apps/downloads/bazarr/ks.yaml
@@ -1,37 +1,37 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app bazarr
-  namespace: &namespace downloads
-spec:
-  components:
-    - ../../../../components/authentik-proxy
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: postgres-cluster
-      namespace: database
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/downloads/bazarr/app
-  postBuild:
-    substitute:
-      APP: *app
-
-      APP_GID: "5000"
-      HOSTNAME: bazarr.${PUBLIC_DOMAIN}
-      PVC_CLAIM: bazarr-config
-      PVC_STORAGECLASS: ix-nfs
-
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app bazarr
+#   namespace: &namespace downloads
+# spec:
+#   components:
+#     - ../../../../components/authentik-proxy
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: postgres-cluster
+#       namespace: database
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/downloads/bazarr/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#
+#       APP_GID: "5000"
+#       HOSTNAME: bazarr.${PUBLIC_DOMAIN}
+#       PVC_CLAIM: bazarr-config
+#       PVC_STORAGECLASS: ix-nfs
+#
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/downloads/lidarr/ks.yaml
+++ b/kubernetes/apps/downloads/lidarr/ks.yaml
@@ -1,33 +1,33 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app lidarr
-  namespace: &namespace downloads
-spec:
-  components:
-    - ../../../../components/authentik-proxy
-    - ../../../../components/pvc
-  dependsOn:
-    - name: postgres-cluster
-      namespace: database
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/downloads/lidarr/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: music.${PUBLIC_DOMAIN}
-      PVC_CAPACITY: 5Gi
-      PVC_CLAIM: lidarr-config
-      PVC_STORAGECLASS: ix-nfs
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app lidarr
+#   namespace: &namespace downloads
+# spec:
+#   components:
+#     - ../../../../components/authentik-proxy
+#     - ../../../../components/pvc
+#   dependsOn:
+#     - name: postgres-cluster
+#       namespace: database
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/downloads/lidarr/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: music.${PUBLIC_DOMAIN}
+#       PVC_CAPACITY: 5Gi
+#       PVC_CLAIM: lidarr-config
+#       PVC_STORAGECLASS: ix-nfs
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -1,33 +1,33 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app qbittorrent
-  namespace: &namespace downloads
-spec:
-  components:
-    - ../../../../components/authentik-proxy
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: ix-csi
-      namespace: storage
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/downloads/qbittorrent/app
-  postBuild:
-    substitute:
-      APP: *app
-
-      APP_GID: "5000"
-      HOSTNAME: torrent.${PUBLIC_DOMAIN}
-      PVC_CLAIM: qbittorrent-config
-      PVC_STORAGECLASS: ix-nfs
-
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app qbittorrent
+#   namespace: &namespace downloads
+# spec:
+#   components:
+#     - ../../../../components/authentik-proxy
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: ix-csi
+#       namespace: storage
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/downloads/qbittorrent/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#
+#       APP_GID: "5000"
+#       HOSTNAME: torrent.${PUBLIC_DOMAIN}
+#       PVC_CLAIM: qbittorrent-config
+#       PVC_STORAGECLASS: ix-nfs
+#
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/downloads/radarr/ks.yaml
+++ b/kubernetes/apps/downloads/radarr/ks.yaml
@@ -1,32 +1,32 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app radarr
-  namespace: &namespace downloads
-spec:
-  components:
-    - ../../../../components/authentik-proxy
-    - ../../../../components/pvc
-  dependsOn:
-    - name: postgres-cluster
-      namespace: database
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/downloads/radarr/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: movies.${PUBLIC_DOMAIN}
-      PVC_CLAIM: radarr-config
-      PVC_STORAGECLASS: ix-nfs
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app radarr
+#   namespace: &namespace downloads
+# spec:
+#   components:
+#     - ../../../../components/authentik-proxy
+#     - ../../../../components/pvc
+#   dependsOn:
+#     - name: postgres-cluster
+#       namespace: database
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/downloads/radarr/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: movies.${PUBLIC_DOMAIN}
+#       PVC_CLAIM: radarr-config
+#       PVC_STORAGECLASS: ix-nfs
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/downloads/recyclarr/ks.yaml
+++ b/kubernetes/apps/downloads/recyclarr/ks.yaml
@@ -1,31 +1,31 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app recyclarr
-  namespace: &namespace downloads
-spec:
-  components:
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: ix-csi
-      namespace: storage
-    - name: external-secrets
-      namespace: security
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/downloads/recyclarr/app
-  postBuild:
-    substitute:
-      APP: *app
-      PVC_CLAIM: recyclarr-config
-      PVC_STORAGECLASS: ix-nfs
-
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app recyclarr
+#   namespace: &namespace downloads
+# spec:
+#   components:
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: ix-csi
+#       namespace: storage
+#     - name: external-secrets
+#       namespace: security
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/downloads/recyclarr/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       PVC_CLAIM: recyclarr-config
+#       PVC_STORAGECLASS: ix-nfs
+#
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/downloads/slskd/ks.yaml
+++ b/kubernetes/apps/downloads/slskd/ks.yaml
@@ -1,34 +1,34 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app slskd
-  namespace: &namespace downloads
-spec:
-  components:
-    - ../../../../components/authentik-proxy
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: ix-csi
-      namespace: storage
-    - name: external-secrets
-      namespace: security
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/downloads/slskd/app
-  postBuild:
-    substitute:
-      APP: *app
-
-      APP_GID: "5000"
-      HOSTNAME: slskd.${PUBLIC_DOMAIN}
-      PVC_CLAIM: slskd-config
-
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app slskd
+#   namespace: &namespace downloads
+# spec:
+#   components:
+#     - ../../../../components/authentik-proxy
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: ix-csi
+#       namespace: storage
+#     - name: external-secrets
+#       namespace: security
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/downloads/slskd/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#
+#       APP_GID: "5000"
+#       HOSTNAME: slskd.${PUBLIC_DOMAIN}
+#       PVC_CLAIM: slskd-config
+#
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/downloads/sonarr/ks.yaml
+++ b/kubernetes/apps/downloads/sonarr/ks.yaml
@@ -1,32 +1,32 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app sonarr
-  namespace: &namespace downloads
-spec:
-  components:
-    - ../../../../components/authentik-proxy
-    - ../../../../components/pvc
-  dependsOn:
-    - name: postgres-cluster
-      namespace: database
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/downloads/sonarr/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: tv.${PUBLIC_DOMAIN}
-      PVC_CLAIM: sonarr-config
-      PVC_STORAGECLASS: ix-nfs
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app sonarr
+#   namespace: &namespace downloads
+# spec:
+#   components:
+#     - ../../../../components/authentik-proxy
+#     - ../../../../components/pvc
+#   dependsOn:
+#     - name: postgres-cluster
+#       namespace: database
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/downloads/sonarr/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: tv.${PUBLIC_DOMAIN}
+#       PVC_CLAIM: sonarr-config
+#       PVC_STORAGECLASS: ix-nfs
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/monitor/kromgo/ks.yaml
+++ b/kubernetes/apps/monitor/kromgo/ks.yaml
@@ -1,22 +1,22 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app kromgo
-  namespace: &namespace monitor
-spec:
-  dependsOn:
-    - name: kube-prometheus-stack
-      namespace: monitor
-  interval: 30m
-  path: ./kubernetes/apps/monitor/kromgo/app
-  postBuild:
-    substitute:
-      HOSTNAME: kromgo.${PUBLIC_DOMAIN}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app kromgo
+#   namespace: &namespace monitor
+# spec:
+#   dependsOn:
+#     - name: kube-prometheus-stack
+#       namespace: monitor
+#   interval: 30m
+#   path: ./kubernetes/apps/monitor/kromgo/app
+#   postBuild:
+#     substitute:
+#       HOSTNAME: kromgo.${PUBLIC_DOMAIN}
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/monitor/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/monitor/kube-prometheus-stack/ks.yaml
@@ -1,26 +1,26 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app kube-prometheus-stack
-  namespace: &namespace monitor
-spec:
-  dependsOn:
-    - name: ix-csi
-      namespace: storage
-    - name: external-secrets
-      namespace: security
-  interval: 30m
-  path: ./kubernetes/apps/monitor/kube-prometheus-stack/app
-  postBuild:
-    substitute:
-      HOSTNAME: prometheus.${PRIVATE_DOMAIN}
-      ALERT_HOSTNAME: alerts.${PRIVATE_DOMAIN}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
-  wait: true
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app kube-prometheus-stack
+#   namespace: &namespace monitor
+# spec:
+#   dependsOn:
+#     - name: ix-csi
+#       namespace: storage
+#     - name: external-secrets
+#       namespace: security
+#   interval: 30m
+#   path: ./kubernetes/apps/monitor/kube-prometheus-stack/app
+#   postBuild:
+#     substitute:
+#       HOSTNAME: prometheus.${PRIVATE_DOMAIN}
+#       ALERT_HOSTNAME: alerts.${PRIVATE_DOMAIN}
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace
+#   wait: true

--- a/kubernetes/apps/monitor/thanos/ks.yaml
+++ b/kubernetes/apps/monitor/thanos/ks.yaml
@@ -1,23 +1,23 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app thanos
-  namespace: &namespace monitor
-spec:
-  dependsOn:
-    - name: ix-csi
-      namespace: storage
-    - name: external-secrets
-      namespace: security
-    - name: kube-prometheus-stack
-      namespace: monitor
-  interval: 30m
-  path: ./kubernetes/apps/monitor/thanos/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app thanos
+#   namespace: &namespace monitor
+# spec:
+#   dependsOn:
+#     - name: ix-csi
+#       namespace: storage
+#     - name: external-secrets
+#       namespace: security
+#     - name: kube-prometheus-stack
+#       namespace: monitor
+#   interval: 30m
+#   path: ./kubernetes/apps/monitor/thanos/app
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/security/vaultwarden/ks.yaml
+++ b/kubernetes/apps/security/vaultwarden/ks.yaml
@@ -1,37 +1,37 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/ishioni/CRDs-catalog/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app vaultwarden
-  namespace: &namespace security
-spec:
-  components:
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: postgres-cluster
-      namespace: database
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/security/vaultwarden/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: passwords.${PUBLIC_DOMAIN}
-
-      PVC_CLAIM: vaultwarden-data
-      PVC_ACCESSMODES: ReadWriteMany
-      PVC_STORAGECLASS: ix-nfs
-
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
-  wait: false
+# ---
+# # yaml-language-server: $schema=https://raw.githubusercontent.com/ishioni/CRDs-catalog/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app vaultwarden
+#   namespace: &namespace security
+# spec:
+#   components:
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: postgres-cluster
+#       namespace: database
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/security/vaultwarden/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: passwords.${PUBLIC_DOMAIN}
+#
+#       PVC_CLAIM: vaultwarden-data
+#       PVC_ACCESSMODES: ReadWriteMany
+#       PVC_STORAGECLASS: ix-nfs
+#
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace
+#   wait: false

--- a/kubernetes/apps/selfhosted/changedetection/ks.yaml
+++ b/kubernetes/apps/selfhosted/changedetection/ks.yaml
@@ -1,33 +1,33 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app changedetection
-  namespace: &namespace selfhosted
-spec:
-  components:
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: ix-csi
-      namespace: storage
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/selfhosted/changedetection/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: changedetection.${PRIVATE_DOMAIN}
-      APP_UID: "999"
-      APP_GID: "999"
-      PVC_CLAIM: changedetection-data
-      PVC_CAPACITY: 1Gi
-      PVC_STORAGECLASS: ix-nfs
-
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app changedetection
+#   namespace: &namespace selfhosted
+# spec:
+#   components:
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: ix-csi
+#       namespace: storage
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/selfhosted/changedetection/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: changedetection.${PRIVATE_DOMAIN}
+#       APP_UID: "999"
+#       APP_GID: "999"
+#       PVC_CLAIM: changedetection-data
+#       PVC_CAPACITY: 1Gi
+#       PVC_STORAGECLASS: ix-nfs
+#
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/selfhosted/immich/ks.yaml
+++ b/kubernetes/apps/selfhosted/immich/ks.yaml
@@ -1,33 +1,33 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app immich
-  namespace: &namespace selfhosted
-spec:
-  components:
-    - ../../../../components/gpu
-  dependsOn:
-    - name: postgres-cluster
-      namespace: database
-    - name: dragonfly-cluster
-      namespace: database
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-    - name: intel-gpu-resource-driver
-      namespace: kube-system
-  interval: 30m
-  path: ./kubernetes/apps/selfhosted/immich/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: photos.${PUBLIC_DOMAIN}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app immich
+#   namespace: &namespace selfhosted
+# spec:
+#   components:
+#     - ../../../../components/gpu
+#   dependsOn:
+#     - name: postgres-cluster
+#       namespace: database
+#     - name: dragonfly-cluster
+#       namespace: database
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#     - name: intel-gpu-resource-driver
+#       namespace: kube-system
+#   interval: 30m
+#   path: ./kubernetes/apps/selfhosted/immich/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: photos.${PUBLIC_DOMAIN}
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/selfhosted/navidrome/ks.yaml
+++ b/kubernetes/apps/selfhosted/navidrome/ks.yaml
@@ -1,38 +1,38 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app navidrome
-  namespace: &namespace selfhosted
-spec:
-  components:
-    - ../../../../components/authentik-proxy
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: postgres-cluster
-      namespace: database
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/selfhosted/navidrome/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: navidrome.${PUBLIC_DOMAIN}
-
-      APP_GID: "5000"
-      PVC_CLAIM: navidrome-config
-      PVC_CAPACITY: 5Gi
-      KOPIUR_CAPACITY: 5Gi
-
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app navidrome
+#   namespace: &namespace selfhosted
+# spec:
+#   components:
+#     - ../../../../components/authentik-proxy
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: postgres-cluster
+#       namespace: database
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/selfhosted/navidrome/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: navidrome.${PUBLIC_DOMAIN}
+#
+#       APP_GID: "5000"
+#       PVC_CLAIM: navidrome-config
+#       PVC_CAPACITY: 5Gi
+#       KOPIUR_CAPACITY: 5Gi
+#
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace

--- a/kubernetes/apps/selfhosted/opencloud/ks.yaml
+++ b/kubernetes/apps/selfhosted/opencloud/ks.yaml
@@ -1,38 +1,38 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app opencloud
-  namespace: selfhosted
-spec:
-  components:
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/selfhosted/opencloud/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: opencloud.${PUBLIC_DOMAIN}
-      AUTH_HOSTNAME: auth.${PUBLIC_DOMAIN}
-
-      PVC_CLAIM: opencloud-data
-      PVC_CAPACITY: &size 20Gi
-      KOPIUR_CAPACITY: *size
-      PVC_STORAGECLASS: ix-nfs
-
-      PVC_ACCESSMODES: ReadWriteMany
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: selfhosted
-  wait: false
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app opencloud
+#   namespace: selfhosted
+# spec:
+#   components:
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/selfhosted/opencloud/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: opencloud.${PRIVATE_DOMAIN}
+#       AUTH_HOSTNAME: auth.${PRIVATE_DOMAIN}
+#
+#       PVC_CLAIM: opencloud-data
+#       PVC_CAPACITY: &size 20Gi
+#       KOPIUR_CAPACITY: *size
+#       PVC_STORAGECLASS: ix-nfs
+#
+#       PVC_ACCESSMODES: ReadWriteMany
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: selfhosted
+#   wait: false

--- a/kubernetes/apps/selfhosted/paperless/ks.yaml
+++ b/kubernetes/apps/selfhosted/paperless/ks.yaml
@@ -1,39 +1,39 @@
----
-# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app paperless
-  namespace: &namespace selfhosted
-spec:
-  components:
-    - ../../../../components/kopiur
-  dependsOn:
-    - name: postgres-cluster
-      namespace: database
-    - name: dragonfly-cluster
-      namespace: database
-    - name: external-secrets
-      namespace: security
-    - name: ix-csi
-      namespace: storage
-    - name: kopiur
-      namespace: storage
-  interval: 30m
-  path: ./kubernetes/apps/selfhosted/paperless/app
-  postBuild:
-    substitute:
-      APP: *app
-      HOSTNAME: documents.${PRIVATE_DOMAIN}
-
-      PVC_CLAIM: paperless-data
-      PVC_CAPACITY: 5Gi
-      KOPIUR_CAPACITY: 5Gi
-      PVC_STORAGECLASS: ix-nfs
-
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: homelab-ops
-    namespace: flux-system
-  targetNamespace: *namespace
+# ---
+# # yaml-language-server: $schema=https://crd.movishell.pl/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: &app paperless
+#   namespace: &namespace selfhosted
+# spec:
+#   components:
+#     - ../../../../components/kopiur
+#   dependsOn:
+#     - name: postgres-cluster
+#       namespace: database
+#     - name: dragonfly-cluster
+#       namespace: database
+#     - name: external-secrets
+#       namespace: security
+#     - name: ix-csi
+#       namespace: storage
+#     - name: kopiur
+#       namespace: storage
+#   interval: 30m
+#   path: ./kubernetes/apps/selfhosted/paperless/app
+#   postBuild:
+#     substitute:
+#       APP: *app
+#       HOSTNAME: documents.${PRIVATE_DOMAIN}
+#
+#       PVC_CLAIM: paperless-data
+#       PVC_CAPACITY: 5Gi
+#       KOPIUR_CAPACITY: 5Gi
+#       PVC_STORAGECLASS: ix-nfs
+#
+#   prune: true
+#   sourceRef:
+#     kind: GitRepository
+#     name: homelab-ops
+#     namespace: flux-system
+#   targetNamespace: *namespace


### PR DESCRIPTION
## Summary

Disable the application-level Flux Kustomizations that consume the ix-csi storage classes, plus Kromgo because it depends on the Prometheus stack that uses ix-csi-backed storage, while keeping the ix-csi driver itself deployed.

Commented-out Kustomizations:

- Downloads: bazarr, lidarr, qbittorrent, radarr, recyclarr, slskd, sonarr
- Monitoring: kube-prometheus-stack, thanos, kromgo
- Security: vaultwarden
- Self-hosted: changedetection, immich, navidrome, opencloud, paperless

The storage Kustomization at `kubernetes/apps/storage/ix-csi/ks.yaml` is intentionally unchanged.

## Backup status

Before preparing this PR, I triggered and waited for successful manual Kopiur snapshots for all nine active Kopiur-backed PVCs:

- `downloads/bazarr-config`
- `downloads/qbittorrent-config`
- `downloads/recyclarr-config`
- `downloads/slskd-config`
- `security/vaultwarden-data`
- `selfhosted/changedetection-data`
- `selfhosted/navidrome-config`
- `selfhosted/opencloud-data`
- `selfhosted/paperless-data`

All nine runs completed successfully.

## Expected effect

After merge and Flux reconciliation, the 16 application Kustomizations will be removed from the desired state and their managed application resources will be pruned. The ix-csi driver, Kopiur, snapshot-controller, and their storage-level resources remain deployed.

Please review the reclaim behavior of any application-managed PVC/PV resources before merging.