### PR TITLE
feat(cosign): deploy signed http-debug experiment

### DIFF
--- a/kubernetes/apps/cosign-a/http-debug/app/helmrelease.yaml
+++ b/kubernetes/apps/cosign-a/http-debug/app/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.1.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: http-debug
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: http-debug
+  interval: 30m
+  values:
+    controllers:
+      http-debug:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ishioni/http-debug
+              tag: cosign-experiment@sha256:14cc950d792c6a4f04876f3c5438f08f308b1485e9410ea06b2d46fabe63c86a
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: &port 8080
+              readiness: *probes
+    service:
+      app:
+        controller: http-debug
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "${HOSTNAME}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - kind: Service
+                name: http-debug
+                port: *port

--- a/kubernetes/apps/cosign-a/http-debug/app/kustomization.yaml
+++ b/kubernetes/apps/cosign-a/http-debug/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./policy.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/cosign-a/http-debug/app/ocirepository.yaml
+++ b/kubernetes/apps/cosign-a/http-debug/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: http-debug
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/bjw-s-labs/helm.*

--- a/kubernetes/apps/cosign-a/http-debug/ks.yaml
+++ b/kubernetes/apps/cosign-a/http-debug/ks.yaml
@@ -13,6 +13,9 @@ spec:
       namespace: security
   interval: 30m
   path: ./kubernetes/apps/cosign-a/http-debug/app
+  postBuild:
+    substitute:
+      HOSTNAME: cosign-a.${PUBLIC_DOMAIN}
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/cosign-b/http-debug/app/helmrelease.yaml
+++ b/kubernetes/apps/cosign-b/http-debug/app/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.1.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: http-debug
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: http-debug
+  interval: 30m
+  values:
+    controllers:
+      http-debug:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ishioni/http-debug
+              tag: cosign-experiment@sha256:14cc950d792c6a4f04876f3c5438f08f308b1485e9410ea06b2d46fabe63c86a
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: &port 8080
+              readiness: *probes
+    service:
+      app:
+        controller: http-debug
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "${HOSTNAME}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - kind: Service
+                name: http-debug
+                port: *port

--- a/kubernetes/apps/cosign-b/http-debug/app/kustomization.yaml
+++ b/kubernetes/apps/cosign-b/http-debug/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./policy.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/cosign-b/http-debug/app/ocirepository.yaml
+++ b/kubernetes/apps/cosign-b/http-debug/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: http-debug
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/bjw-s-labs/helm.*

--- a/kubernetes/apps/cosign-b/http-debug/ks.yaml
+++ b/kubernetes/apps/cosign-b/http-debug/ks.yaml
@@ -13,6 +13,9 @@ spec:
       namespace: security
   interval: 30m
   path: ./kubernetes/apps/cosign-b/http-debug/app
+  postBuild:
+    substitute:
+      HOSTNAME: cosign-b.${PUBLIC_DOMAIN}
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/cosign-c/http-debug/app/helmrelease.yaml
+++ b/kubernetes/apps/cosign-c/http-debug/app/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.1.0/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: http-debug
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: http-debug
+  interval: 30m
+  values:
+    controllers:
+      http-debug:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ishioni/http-debug
+              tag: cosign-experiment@sha256:14cc950d792c6a4f04876f3c5438f08f308b1485e9410ea06b2d46fabe63c86a
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: &port 8080
+              readiness: *probes
+    service:
+      app:
+        controller: http-debug
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "${HOSTNAME}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - kind: Service
+                name: http-debug
+                port: *port

--- a/kubernetes/apps/cosign-c/http-debug/app/kustomization.yaml
+++ b/kubernetes/apps/cosign-c/http-debug/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./policy.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/cosign-c/http-debug/app/ocirepository.yaml
+++ b/kubernetes/apps/cosign-c/http-debug/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: http-debug
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/bjw-s-labs/helm.*

--- a/kubernetes/apps/cosign-c/http-debug/ks.yaml
+++ b/kubernetes/apps/cosign-c/http-debug/ks.yaml
@@ -13,6 +13,9 @@ spec:
       namespace: security
   interval: 30m
   path: ./kubernetes/apps/cosign-c/http-debug/app
+  postBuild:
+    substitute:
+      HOSTNAME: cosign-c.${PUBLIC_DOMAIN}
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

- deploy the dual-signed `http-debug` image to `cosign-a`, `cosign-b`, and `cosign-c`
- pin the immutable image digest verified during the Cosign experiment
- use bjw-s app-template 5.1.0 with verified OCI chart sources
- expose each deployment through the external Envoy Gateway

## Endpoints

- `https://cosign-a.movishell.pl`
- `https://cosign-b.movishell.pl`
- `https://cosign-c.movishell.pl`

## Expected behavior

| Namespace | Trusted key | Expected result |
| --- | --- | --- |
| `cosign-a` | A | Pod admitted and endpoint healthy |
| `cosign-b` | B | Pod admitted and endpoint healthy |
| `cosign-c` | C | Pod rejected because the image has no key C signature |

The image is `ghcr.io/ishioni/http-debug:cosign-experiment@sha256:14cc950d792c6a4f04876f3c5438f08f308b1485e9410ea06b2d46fabe63c86a` and contains OCI Cosign signatures from keys A and B only.

Kyverno controller autogeneration remains disabled intentionally. Helm can create the Deployment, Service, and HTTPRoute in `cosign-c`, while Kyverno rejects the ReplicaSet-created Pod.

## Validation

- confirmed live Kyverno admission controller is 3/3 Ready
- confirmed all three ESO public-key Secrets are synced
- confirmed all three Kyverno policies are Ready
- rendered all namespace and app Kustomizations
- rendered app-template and verified the digest-pinned image, `/readyz` probe, Service port 8080, and HTTPRoute backend
- project diagnostics and pre-commit YAML formatting passed