### PR TITLE
feat(cosign): migrate signature policies to CEL

### DIFF
--- a/kubernetes/apps/cosign-a/http-debug/app/policy.yaml
+++ b/kubernetes/apps/cosign-a/http-debug/app/policy.yaml
@@ -1,35 +1,54 @@
 ---
-# yaml-language-server: $schema=https://crd.movishell.pl/kyverno.io/policy_v1.json
-apiVersion: kyverno.io/v1
-kind: Policy
+# yaml-language-server: $schema=https://crd.movishell.pl/policies.kyverno.io/namespacedimagevalidatingpolicy_v1.json
+apiVersion: policies.kyverno.io/v1
+kind: NamespacedImageValidatingPolicy
 metadata:
   name: verify-http-debug-signature
-  annotations:
-    pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  background: false
+  autogen:
+    podControllers:
+      controllers: []
+  failurePolicy: Fail
+  evaluation:
+    background:
+      enabled: false
   webhookConfiguration:
-    failurePolicy: Fail
     timeoutSeconds: 30
-  rules:
-    - name: verify-signature
-      match:
-        any:
-          - resources:
-              kinds:
-                - Pod
-      verifyImages:
-        - imageReferences:
-            - ghcr.io/ishioni/http-debug:*
-            - ghcr.io/ishioni/http-debug@*
-          failureAction: Enforce
-          mutateDigest: true
-          required: true
-          verifyDigest: true
-          attestors:
-            - count: 1
-              entries:
-                - keys:
-                    publicKeys: k8s://cosign-a/cosign-public-key
-                    rekor:
-                      ignoreTlog: true
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+  matchImageReferences:
+    - glob: ghcr.io/ishioni/http-debug:*
+    - glob: ghcr.io/ishioni/http-debug@*
+  variables:
+    - name: keySecret
+      expression: >-
+        resource.get("v1", "secrets", "cosign-public-key")
+  attestors:
+    - name: cosign
+      cosign:
+        key:
+          expression: >-
+            string(base64.decode(variables.keySecret.data["cosign.pub"]))
+        ctlog:
+          insecureIgnoreTlog: true
+  validationConfigurations:
+    mutateDigest: true
+    required: true
+    verifyDigest: true
+  validations:
+    - expression: >-
+        images.containers.map(image,
+          verifyImageSignatures(image, [attestors.cosign])
+        ).all(result, result > 0)
+      message: failed to verify image signature

--- a/kubernetes/apps/cosign-b/http-debug/app/policy.yaml
+++ b/kubernetes/apps/cosign-b/http-debug/app/policy.yaml
@@ -1,35 +1,54 @@
 ---
-# yaml-language-server: $schema=https://crd.movishell.pl/kyverno.io/policy_v1.json
-apiVersion: kyverno.io/v1
-kind: Policy
+# yaml-language-server: $schema=https://crd.movishell.pl/policies.kyverno.io/namespacedimagevalidatingpolicy_v1.json
+apiVersion: policies.kyverno.io/v1
+kind: NamespacedImageValidatingPolicy
 metadata:
   name: verify-http-debug-signature
-  annotations:
-    pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  background: false
+  autogen:
+    podControllers:
+      controllers: []
+  failurePolicy: Fail
+  evaluation:
+    background:
+      enabled: false
   webhookConfiguration:
-    failurePolicy: Fail
     timeoutSeconds: 30
-  rules:
-    - name: verify-signature
-      match:
-        any:
-          - resources:
-              kinds:
-                - Pod
-      verifyImages:
-        - imageReferences:
-            - ghcr.io/ishioni/http-debug:*
-            - ghcr.io/ishioni/http-debug@*
-          failureAction: Enforce
-          mutateDigest: true
-          required: true
-          verifyDigest: true
-          attestors:
-            - count: 1
-              entries:
-                - keys:
-                    publicKeys: k8s://cosign-b/cosign-public-key
-                    rekor:
-                      ignoreTlog: true
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+  matchImageReferences:
+    - glob: ghcr.io/ishioni/http-debug:*
+    - glob: ghcr.io/ishioni/http-debug@*
+  variables:
+    - name: keySecret
+      expression: >-
+        resource.get("v1", "secrets", "cosign-public-key")
+  attestors:
+    - name: cosign
+      cosign:
+        key:
+          expression: >-
+            string(base64.decode(variables.keySecret.data["cosign.pub"]))
+        ctlog:
+          insecureIgnoreTlog: true
+  validationConfigurations:
+    mutateDigest: true
+    required: true
+    verifyDigest: true
+  validations:
+    - expression: >-
+        images.containers.map(image,
+          verifyImageSignatures(image, [attestors.cosign])
+        ).all(result, result > 0)
+      message: failed to verify image signature

--- a/kubernetes/apps/cosign-c/http-debug/app/policy.yaml
+++ b/kubernetes/apps/cosign-c/http-debug/app/policy.yaml
@@ -1,35 +1,54 @@
 ---
-# yaml-language-server: $schema=https://crd.movishell.pl/kyverno.io/policy_v1.json
-apiVersion: kyverno.io/v1
-kind: Policy
+# yaml-language-server: $schema=https://crd.movishell.pl/policies.kyverno.io/namespacedimagevalidatingpolicy_v1.json
+apiVersion: policies.kyverno.io/v1
+kind: NamespacedImageValidatingPolicy
 metadata:
   name: verify-http-debug-signature
-  annotations:
-    pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  background: false
+  autogen:
+    podControllers:
+      controllers: []
+  failurePolicy: Fail
+  evaluation:
+    background:
+      enabled: false
   webhookConfiguration:
-    failurePolicy: Fail
     timeoutSeconds: 30
-  rules:
-    - name: verify-signature
-      match:
-        any:
-          - resources:
-              kinds:
-                - Pod
-      verifyImages:
-        - imageReferences:
-            - ghcr.io/ishioni/http-debug:*
-            - ghcr.io/ishioni/http-debug@*
-          failureAction: Enforce
-          mutateDigest: true
-          required: true
-          verifyDigest: true
-          attestors:
-            - count: 1
-              entries:
-                - keys:
-                    publicKeys: k8s://cosign-c/cosign-public-key
-                    rekor:
-                      ignoreTlog: true
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+  matchImageReferences:
+    - glob: ghcr.io/ishioni/http-debug:*
+    - glob: ghcr.io/ishioni/http-debug@*
+  variables:
+    - name: keySecret
+      expression: >-
+        resource.get("v1", "secrets", "cosign-public-key")
+  attestors:
+    - name: cosign
+      cosign:
+        key:
+          expression: >-
+            string(base64.decode(variables.keySecret.data["cosign.pub"]))
+        ctlog:
+          insecureIgnoreTlog: true
+  validationConfigurations:
+    mutateDigest: true
+    required: true
+    verifyDigest: true
+  validations:
+    - expression: >-
+        images.containers.map(image,
+          verifyImageSignatures(image, [attestors.cosign])
+        ).all(result, result > 0)
+      message: failed to verify image signature


### PR DESCRIPTION
## Summary

- migrate the three `kyverno.io/v1` namespaced `Policy` resources to `policies.kyverno.io/v1` `NamespacedImageValidatingPolicy`
- load each namespace-local `cosign-public-key` Secret through the namespaced CEL resource library and decode `cosign.pub`
- preserve fail-closed admission, digest mutation/verification, disabled background evaluation, disabled pod-controller autogen, and ignored transparency-log verification

## Expected behavior

- `cosign-a` accepts the image signed by key A
- `cosign-b` accepts the image signed by key B
- `cosign-c` continues rejecting the image because it is not signed by key C

## Validation

- rendered all three app and namespace Kustomizations with `kubectl kustomize`
- passed live Kyverno 1.18.2 server-side dry-run and CEL compilation in all three namespaces
- passed YAML schema diagnostics and `git diff --check`
- passed the repository `format-yaml` pre-commit hook