### PR TITLE
feat(security): deploy Vault with Authentik OIDC

### DIFF
--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./external-secrets/ks.yaml
   - ./onepassword/ks.yaml
   - ./vaultwarden/ks.yaml
+  - ./vault/ks.yaml

--- a/kubernetes/apps/security/vault/app/externalsecret.yaml
+++ b/kubernetes/apps/security/vault/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name vault-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        OIDC_DISCOVERY_URL: https://auth.movishell.pl/application/o/vault/
+        OIDC_CLIENT_ID: "{{ .OIDC_CLIENT_ID }}"
+        OIDC_CLIENT_SECRET: "{{ .OIDC_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: vault

--- a/kubernetes/apps/security/vault/app/helmrelease.yaml
+++ b/kubernetes/apps/security/vault/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vault
+spec:
+  chart:
+    spec:
+      chart: vault
+      # renovate: datasource=helm depName=vault registryUrl=https://helm.releases.hashicorp.com
+      version: 0.34.1
+      sourceRef:
+        kind: HelmRepository
+        name: vault
+        namespace: security
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    global:
+      tlsDisable: true
+
+    injector:
+      enabled: true
+      replicas: 1
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          memory: 256Mi
+
+    server:
+      enabled: true
+      updateStrategyType: RollingUpdate
+      extraSecretEnvironmentVars:
+        - envName: VAULT_OIDC_DISCOVERY_URL
+          secretName: vault-secret
+          secretKey: OIDC_DISCOVERY_URL
+        - envName: VAULT_OIDC_CLIENT_ID
+          secretName: vault-secret
+          secretKey: OIDC_CLIENT_ID
+        - envName: VAULT_OIDC_CLIENT_SECRET
+          secretName: vault-secret
+          secretKey: OIDC_CLIENT_SECRET
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+      dataStorage:
+        enabled: true
+        size: 10Gi
+        storageClass: ix-nvmeof
+        accessMode: ReadWriteOnce
+      ha:
+        enabled: true
+        replicas: 1
+        disruptionBudget:
+          enabled: false
+        raft:
+          enabled: true
+          setNodeId: true
+          config: |-
+            ui = true
+
+            listener "tcp" {
+              tls_disable = 1
+              address = "[::]:8200"
+              cluster_address = "[::]:8201"
+            }
+
+            storage "raft" {
+              path = "/vault/data"
+            }
+
+            service_registration "kubernetes" {}
+
+      httproute:
+        enabled: true
+        activeService: false
+        hostnames:
+          - vault.ishioni.casa
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+
+    ui:
+      enabled: true
+      serviceType: ClusterIP

--- a/kubernetes/apps/security/vault/app/helmrepository.yaml
+++ b/kubernetes/apps/security/vault/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: vault
+spec:
+  interval: 1h
+  url: https://helm.releases.hashicorp.com

--- a/kubernetes/apps/security/vault/app/kustomization.yaml
+++ b/kubernetes/apps/security/vault/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/kustomize.config.k8s.io/kustomization_v1beta1.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml

--- a/kubernetes/apps/security/vault/ks.yaml
+++ b/kubernetes/apps/security/vault/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ishioni/CRDs-catalog/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vault
+  namespace: &namespace security
+spec:
+  dependsOn:
+    - name: external-secrets
+      namespace: security
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  interval: 30m
+  path: ./kubernetes/apps/security/vault/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab-ops
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/terraform/authentik/applications.tofu
+++ b/terraform/authentik/applications.tofu
@@ -292,6 +292,23 @@ module "oauth2-vaultwarden" {
   access_token_validity = "hours=1"
 }
 
+module "oauth2-vault" {
+  source                = "./modules/oauth2_application"
+  name                  = "Vault"
+  icon_url              = "https://www.vaultproject.io/favicon.ico"
+  launch_url            = "https://vault.${var.private_domain}"
+  description           = "Secrets management"
+  newtab                = true
+  group                 = "Infrastructure"
+  auth_groups           = [authentik_group.infrastructure.id]
+  authorization_flow    = resource.authentik_flow.provider-authorization-implicit-consent.uuid
+  invalidation_flow     = resource.authentik_flow.provider-invalidation.uuid
+  client_id             = module.secret_vault.fields["OIDC_CLIENT_ID"]
+  client_secret         = module.secret_vault.fields["OIDC_CLIENT_SECRET"]
+  redirect_uris         = ["https://vault.${var.private_domain}/ui/vault/auth/oidc/oidc/callback"]
+  access_token_validity = "hours=1"
+}
+
 # module "oauth2-openwebui" {
 #   source             = "./modules/oauth2_application"
 #   name               = "OpenWebUI"

--- a/terraform/authentik/main.tofu
+++ b/terraform/authentik/main.tofu
@@ -55,6 +55,12 @@ module "secret_vaultwarden" {
   item   = "vaultwarden"
 }
 
+module "secret_vault" {
+  source = "./modules/1password-item"
+  vault  = "Homelab"
+  item   = "vault"
+}
+
 module "secret_fluxcd" {
   source = "./modules/1password-item"
   vault  = "Homelab"


### PR DESCRIPTION
## Summary

- deploy HashiCorp Vault in the security namespace with the vault-helm chart
- use persistent single-node Raft storage on ix-nvmeof
- expose the Vault UI through the internal Envoy Gateway at vault.ishioni.casa
- add an Authentik OAuth2 application and 1Password-backed client credentials
- sync OIDC settings into Vault through External Secrets

## Validation

- kubectl kustomize passed for the security and Vault manifests
- Helm template and helm lint passed for chart 0.34.1
- OpenTofu formatting passed for the changed main.tofu file
- mise-managed pre-commit hook passed, including oxfmt

OpenTofu validate was not completed because the local module cache required initialization and tofu init timed out. Vault OIDC backend initialization remains a one-time post-deployment operator step after Vault is initialized and unsealed.