### PR TITLE
chore(storage): remove ix-csi iSCSI portal

### DIFF
--- a/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/ix-csi/app/helmrelease.yaml
@@ -19,7 +19,6 @@ spec:
       truenasInsecure: false
       defaultPool: SSD
       nfsServer: leo.ishioni.casa
-      iscsiPortal: 10.1.2.2:3260
       nvmeofPortal: 10.1.2.2:4420
       iscsiIQNBase: iqn.2011-08.org.truenas.ctl
     secret:


### PR DESCRIPTION
## Summary
- remove the explicit iSCSI portal from the ix-csi HelmRelease values
- retain the existing NFS and NVMe-oF storage class configuration

## Validation
- rendered the ix-csi chart with the HelmRelease values
- confirmed TRUENAS_ISCSI_PORTAL is absent and only ix-nfs and ix-nvmeof storage classes are produced