### PR TITLE
feat(renovate): protect operator UI with Authentik OIDC

### DIFF
--- a/kubernetes/apps/github/renovate/app/externalsecret.yaml
+++ b/kubernetes/apps/github/renovate/app/externalsecret.yaml
@@ -14,7 +14,11 @@ spec:
     template:
       type: Opaque
       engineVersion: v2
+      metadata:
+        labels:
+          reconcile.fluxcd.io/watch: Enabled
       data:
+        client-id: "{{ .OIDC_CLIENT_ID }}"
         client-secret: "{{ .OIDC_CLIENT_SECRET }}"
         session-secret: "{{ .SESSION_SECRET }}"
   dataFrom:

--- a/kubernetes/apps/github/renovate/app/externalsecret.yaml
+++ b/kubernetes/apps/github/renovate/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name renovate-operator-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        client-secret: "{{ .OIDC_CLIENT_SECRET }}"
+        session-secret: "{{ .SESSION_SECRET }}"
+  dataFrom:
+    - extract:
+        key: renovate-operator

--- a/kubernetes/apps/github/renovate/app/helmrelease.yaml
+++ b/kubernetes/apps/github/renovate/app/helmrelease.yaml
@@ -17,6 +17,9 @@ spec:
       literal: true
   values:
     fullnameOverride: renovate-operator
+    deployment:
+      annotations:
+        secret.reloader.stakater.com/reload: renovate-operator-oidc
     route:
       annotations:
         gatus.home-operations.com/endpoint: "name: renovate-operator"

--- a/kubernetes/apps/github/renovate/app/helmrelease.yaml
+++ b/kubernetes/apps/github/renovate/app/helmrelease.yaml
@@ -9,6 +9,12 @@ spec:
     kind: OCIRepository
     name: renovate-operator
   interval: 30m
+  valuesFrom:
+    - kind: Secret
+      name: renovate-operator-oidc
+      valuesKey: client-id
+      targetPath: auth.oidc.clientId
+      literal: true
   values:
     fullnameOverride: renovate-operator
     route:
@@ -24,7 +30,6 @@ spec:
       oidc:
         enabled: true
         issuerUrl: https://auth.movishell.pl/application/o/renovate-operator/
-        clientId: renovate-operator
         existingSecret: renovate-operator-oidc
         secretKey: client-secret
         sessionSecretKey: session-secret

--- a/kubernetes/apps/github/renovate/app/helmrelease.yaml
+++ b/kubernetes/apps/github/renovate/app/helmrelease.yaml
@@ -20,6 +20,17 @@ spec:
         - name: envoy-internal
           namespace: network
           sectionName: https
+    auth:
+      oidc:
+        enabled: true
+        issuerUrl: https://auth.movishell.pl/application/o/renovate-operator/
+        clientId: renovate-operator
+        existingSecret: renovate-operator-oidc
+        secretKey: client-secret
+        sessionSecretKey: session-secret
+        redirectScheme: https
+    authorization:
+      enabled: false
     webhook:
       enabled: true
     metrics:

--- a/kubernetes/apps/github/renovate/app/kustomization.yaml
+++ b/kubernetes/apps/github/renovate/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/terraform/authentik/applications.tofu
+++ b/terraform/authentik/applications.tofu
@@ -192,6 +192,21 @@ module "oauth2-flux" {
   redirect_uris      = ["https://flux.${var.private_domain}/oauth2/callback"]
 }
 
+module "oauth2-renovate-operator" {
+  source             = "./modules/oauth2_application"
+  name               = "Renovate Operator"
+  slug               = "renovate-operator"
+  description        = "Renovate dependency update dashboard"
+  launch_url         = "https://renovate.${var.private_domain}"
+  group              = "Infrastructure"
+  auth_groups        = [authentik_group.infrastructure.id]
+  authorization_flow = resource.authentik_flow.provider-authorization-implicit-consent.uuid
+  invalidation_flow  = resource.authentik_flow.provider-invalidation.uuid
+  client_id          = module.secret_renovate_operator.fields["OIDC_CLIENT_ID"]
+  client_secret      = module.secret_renovate_operator.fields["OIDC_CLIENT_SECRET"]
+  redirect_uris      = ["https://renovate.${var.private_domain}/auth/callback"]
+}
+
 module "oauth2-immich" {
   source             = "./modules/oauth2_application"
   name               = "Immich"

--- a/terraform/authentik/applications.tofu
+++ b/terraform/authentik/applications.tofu
@@ -195,6 +195,7 @@ module "oauth2-flux" {
 module "oauth2-renovate-operator" {
   source             = "./modules/oauth2_application"
   name               = "Renovate Operator"
+  icon_url           = "https://raw.githubusercontent.com/mogenius/renovate-operator/main/src/static/assets/favicon.png"
   slug               = "renovate-operator"
   description        = "Renovate dependency update dashboard"
   launch_url         = "https://renovate.${var.private_domain}"

--- a/terraform/authentik/main.tofu
+++ b/terraform/authentik/main.tofu
@@ -73,6 +73,12 @@ module "secret_toolhive" {
   item   = "toolhive"
 }
 
+module "secret_renovate_operator" {
+  source = "./modules/1password-item"
+  vault  = "Homelab"
+  item   = "renovate-operator"
+}
+
 provider "authentik" {
   url   = module.secret_authentik.fields["ENDPOINT_URL"]
   token = module.secret_authentik.fields["TERRAFORM_TOKEN"]


### PR DESCRIPTION
## Summary

- Enable Renovate Operator OIDC authentication against Authentik.
- Persist the OIDC client secret and session encryption secret through External Secrets.
- Force HTTPS for the Gateway API callback URL.
- Keep authorization disabled so any authenticated Authentik user is an admin, avoiding a dependency on group claims for this single-user operator.

## Authentik setup

Create an Authentik OAuth2/OpenID provider and application with:

- Client ID: renovate-operator
- Issuer: https://auth.movishell.pl/application/o/renovate-operator/
- Redirect URI: https://renovate.<PRIVATE_DOMAIN>/auth/callback
- Scopes: openid, email, profile

Create a 1Password item named renovate-operator with fields:

- OIDC_CLIENT_SECRET
- SESSION_SECRET

The ExternalSecret renders these into renovate-operator-oidc as client-secret and session-secret. No credential values are stored in Git.

## Validation

- kustomize build kubernetes/apps/github/renovate/app
- repository pre-commit YAML formatting
- git diff --check